### PR TITLE
fix: `react-shiki` resolution error when deploying

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -1,30 +1,9 @@
-# React + TypeScript + Vite
+# react-shiki-examples
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+See [package/readme](../package/README.md) for more information about `react-shiki`
 
-Currently, two official plugins are available:
+## Run Playground
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json', './tsconfig.app.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
+```bash
+[pnpm|yarn|bun|npm] run playground:dev
 ```
-
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-shiki": "workspace:*"
+    "react-shiki": "^0.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-shiki:
-        specifier: workspace:*
-        version: link:../package
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -1333,6 +1333,12 @@ packages:
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
+
+  react-shiki@0.1.0:
+    resolution: {integrity: sha512-8nxx2G9a1BOgWAks1FflHnDnB2Gl82w3Yph8S+WzQpII7k5kA6KCTAyjhpSNJpKb3UF8AeIu+htD8QX/wDme2w==}
+    peerDependencies:
+      react: '>= 15.0.0'
+      react-dom: '>= 15.0.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2808,6 +2814,16 @@ snapshots:
   react-property@2.0.2: {}
 
   react-refresh@0.14.2: {}
+
+  react-shiki@0.1.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      html-react-parser: 5.1.12(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      shiki: 1.12.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
**EDIT:** Not needed, we can use the workspace version of the package by adding a `"prebuild"` script in the playground's `package.json`:

```json
"prebuild": "pnpm --filter react-shiki run build"
```

This ensures that the `react-shiki` package is built before the playground is deployed, allowing Vercel to correctly resolve and use the workspace version of the package.

---
~~This branch is maintained as the production deployment branch.~~

This branch imports the `react-shiki` package from NPM instead of using the package from the monorepo workspace.

Vercel was unable to resolve `react-shiki` when using the `react-shiki: workspace*`, despite the setting to include files outside of the root dir (playground) being enabled.