### PR TITLE
feat: Add rehype inline plugin for more accurate checking

### DIFF
--- a/.changeset/loud-cobras-repeat.md
+++ b/.changeset/loud-cobras-repeat.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Accuartely check inline code with exported rehype inline code plugin, sets inline prop when passed to react markdown

--- a/package/README.md
+++ b/package/README.md
@@ -16,6 +16,7 @@ for react using [Shiki](https://shiki.matsu.io/)
   - [Installation](#installation)
   - [Usage](#usage)
     - [`react-markdown`](#react-markdown)
+    - [Check if code is inline](#check-if-code-is-inline)
     - [Custom themes](#custom-themes)
   - [Performance](#performance)
     - [Throttling real-time highlighting](#throttling-real-time-highlighting)
@@ -74,7 +75,10 @@ function CodeBlock() {
 }
 ```
 
-The `ShikiHighlighter` component will follow a similar API to `react-syntax-highlighter`, but uses Shiki and is optimized for performant sequential highlighting. As of now, not all of `react-syntax-highlighter` functionality is supported, but the goal of this component is to eventually act as a drop in replacement for `react-syntax-highlighter`.
+The `ShikiHighlighter` component will follow a similar API to `react-syntax-highlighter`,
+but uses Shiki and is optimized for performant sequential highlighting. As of now,
+not all of `react-syntax-highlighter` functionality is supported, but the goal of
+this component is to eventually act as a drop in replacement for `react-syntax-highlighter`.
 
 The component accepts several props in addition to language and theme:
 
@@ -108,22 +112,6 @@ function Houston() {
     </ShikiHighlighter>
   );
 }
-```
-
-`react-shiki` exports `isInlineCode` to check if a code block is inline:
-
-```tsx
-const isInline: boolean | undefined = node ? isInlineCode(node) : undefined;
-
-return !isInline ? (
-  <ShikiHighlighter language={language} theme={"houston"} {...props}>
-    {String(children)}
-  </ShikiHighlighter>
-) : (
-  <code className={className} {...props}>
-    {children}
-  </code>
-);
 ```
 
 ### `react-markdown`
@@ -166,6 +154,69 @@ import { CodeHighlight } from "./CodeHighlight";
 >
   {markdown}
 </ReactMarkdown>;
+```
+
+### Check if code is inline
+
+There are two ways to check if a code block is inline:
+`react-shiki` exports `isInlineCode`, good but marks multiline inline
+code tags as code blocks.
+
+```tsx
+const isInline: boolean | undefined = node ? isInlineCode(node) : undefined;
+
+return !isInline ? (
+  <ShikiHighlighter language={language} theme={"houston"} {...props}>
+    {String(children)}
+  </ShikiHighlighter>
+) : (
+  <code className={className} {...props}>
+    {children}
+  </code>
+);
+```
+
+`react-shiki` also exports `rehypeInlineCodeProperty`, a more accurate way
+to determine if code is inline.
+It's passed as a rehype plugin to `react-markdown`:
+
+```tsx
+import ReactMarkdown from "react-markdown";
+import { rehypeInlineCodeProperty } from "react-shiki";
+
+<ReactMarkdown
+  rehypePlugins={[rehypeInlineCodeProperty]}
+  components={{
+    code: CodeHighlight,
+  }}
+>
+  {markdown}
+</ReactMarkdown>;
+```
+
+And can be accessed as a prop:
+
+```tsx
+const CodeHighlight = ({
+  inline,
+  className,
+  children,
+  node,
+  ...props
+}: CodeHighlightProps): JSX.Element => {
+  const match = className?.match(/language-(\w+)/);
+  const language = match ? match[1] : undefined;
+
+
+return !inline ? (
+  <ShikiHighlighter language={language} theme={"houston"} {...props}>
+    {String(children)}
+  </ShikiHighlighter>
+) : (
+  <code className={className} {...props}>
+    {children}
+  </code>
+);
 ```
 
 ### Custom themes

--- a/package/package.json
+++ b/package/package.json
@@ -48,7 +48,8 @@
     "@types/jest": "^29.5.14",
     "clsx": "^2.1.1",
     "html-react-parser": "^5.1.12",
-    "shiki": "^1.12.1"
+    "shiki": "^1.12.1",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,3 @@
 export { ShikiHighlighter as default } from './ShikiHighlighter';
 export { useShikiHighlighter } from './useShiki';
-export { isInlineCode, type Element } from './utils';
+export { isInlineCode, rehypeInlineCodeProperty, type Element } from './utils';

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -1,6 +1,48 @@
-import type { Element } from 'hast';
 import type { ShikiTransformer } from 'shiki';
+import type { Element, Root } from 'hast';
+import { visit } from 'unist-util-visit';
 
+/**
+ * This augmentation ensures that hast.RootData includes the same
+ * index signature as unist.Data, preventing type incompatibilities
+ * when we pass a hast.Root to unist-util-visit (which expects Node<Data>).
+ */
+declare module 'hast' {
+  interface RootData {
+    [key: string]: unknown;
+  }
+}
+
+
+/**
+ * Rehype plugin to add an 'inline' property to <code> elements.
+ * Sets an 'inline' property to true if the <code> is not within a <pre> tag.
+ *
+ * Pass this plugin to the `rehypePlugins` prop of ReactMarkdown.
+ * You can then access `inline` as a prop from ReactMarkdown.
+ *
+ * @example
+ * import ReactMarkdown from 'react-markdown';
+ * import { rehypeInlineCodeProperty } from 'react-shiki';
+ * <ReactMarkdown rehypePlugins={[rehypeInlineCodeProperty]} />
+ */
+export function rehypeInlineCodeProperty() {
+  return function (tree: Root): undefined {
+    visit(tree as any, 'element', function (node: Element, _index, parent: Element) {
+      if (parent && parent.tagName === 'pre') {
+        node.properties.inline = false;
+      } else {
+        node.properties.inline = true;
+      }
+    });
+  }
+}
+
+
+/**
+ * Less accurate way to determine if code is inline.
+ * Reports `inline = false` for multiline inline code blocks.
+ */
 export const isInlineCode = (node: Element): boolean => {
   return node.position?.start.line === node.position?.end.line;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       shiki:
         specifier: ^1.12.1
         version: 1.12.1
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.0.0
@@ -2146,6 +2149,15 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  unist-util-is@6.0.0:
+    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+
+  unist-util-visit-parents@6.0.1:
+    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -4463,6 +4475,21 @@ snapshots:
   ufo@1.5.4: {}
 
   undici-types@6.20.0: {}
+
+  unist-util-is@6.0.0:
+    dependencies:
+      '@types/unist': 3.0.2
+
+  unist-util-visit-parents@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-is: 6.0.0
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.2
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
feat: Add rehype inline plugin for more accurate checking

Exports rehype plugin that checks if code is inline, more accurate than
using `isInlineCode`. The rehype plugin is passed to React Markdown

chore: Add changeset