### PR TITLE
fix(error): Improve inline utils, update useShiki test

### DIFF
--- a/.changeset/tiny-monkeys-pump.md
+++ b/.changeset/tiny-monkeys-pump.md
@@ -1,0 +1,6 @@
+---
+"react-shiki": patch
+---
+
+- Fix boolean attribute error
+- Improve `isInlineCode` function, achieve parity with `rehypeInlineCodeProperty`

--- a/package/src/__tests__/ShikiHighlighter.test.tsx
+++ b/package/src/__tests__/ShikiHighlighter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { ShikiHighlighter } from '../ShikiHighlighter';
 
 const codeSample = 'console.log("Hello World");';

--- a/package/src/__tests__/useShiki.test.tsx
+++ b/package/src/__tests__/useShiki.test.tsx
@@ -9,29 +9,56 @@ interface TestComponentProps {
   theme: Theme;
 }
 
-const TestComponent: React.FC<TestComponentProps> = ({ code, language, theme }) => {
+const TestComponent  = ({ code, language, theme }: TestComponentProps) => {
   const highlighted = useShikiHighlighter(code, language, theme);
   return <div data-testid="highlighted">{highlighted}</div>;
 };
 
 describe('useShikiHighlighter Hook', () => {
-  test('returns highlighted code output with proper structure', async () => {
-    const { getByTestId } = render(
+  const renderComponent = () => {
+    return render(
       <TestComponent code={'<div>Hello World</div>'} language="html" theme={"github-light"} />
     );
+  };
+
+  test('renders pre element with correct theme classes', async () => {
+    const { getByTestId } = renderComponent();
 
     await waitFor(() => {
       const container = getByTestId('highlighted');
-
-      // Ensure the highlighted code is rendered as a <pre> element with classes "shiki github-light"
       const preElement = container.querySelector('pre.shiki.github-light');
       expect(preElement).toBeInTheDocument();
+    });
+  });
 
-      // Inside the <pre>, a <code> element should be present.
+  test('sets tabindex=-1 on pre element', async () => {
+    const { getByTestId } = renderComponent();
+
+    await waitFor(() => {
+      const container = getByTestId('highlighted');
+      const preElement = container.querySelector('pre.shiki.github-light');
+      expect(preElement).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  test('renders code element inside pre element', async () => {
+    const { getByTestId } = renderComponent();
+
+    await waitFor(() => {
+      const container = getByTestId('highlighted');
+      const preElement = container.querySelector('pre.shiki.github-light');
       const codeElement = preElement?.querySelector('code');
       expect(codeElement).toBeInTheDocument();
+    });
+  });
 
-      // And inside the <code>, at least one <span> with class "line" should be present.
+  test('renders line spans inside code element', async () => {
+    const { getByTestId } = renderComponent();
+
+    await waitFor(() => {
+      const container = getByTestId('highlighted');
+      const preElement = container.querySelector('pre.shiki.github-light');
+      const codeElement = preElement?.querySelector('code');
       const lineSpan = codeElement?.querySelector('span.line');
       expect(lineSpan).toBeInTheDocument();
     });


### PR DESCRIPTION
Fixes non standard boolean error when code blocks are rendered

Modifies the `rehypeInlineCodeProperty` plugin to only set `inline=true` on standalone `code` elements, excluding those within `pre` blocks. Previously, the `inline` attribute was being set on `pre` elements and ended up in the DOM, causing the error.

Also improves the `isInlineCode` util's code detection logic to properly handle text content with line breaks and adds comprehensive test coverage for code block rendering. This makes it's function identical to the rehype plugin