### PR TITLE
feat: Add support for custom Shiki transformers

### DIFF
--- a/.changeset/moody-meals-accept.md
+++ b/.changeset/moody-meals-accept.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": minor
+---
+
+feat: Add support for custom Shiki transformers

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "package:build": "pnpm --filter react-shiki build",
     "playground:dev": "pnpm --filter playground dev",
     "playground:build": "pnpm --filter playground build",
+    "test": "pnpm --filter react-shiki test",
     "lint": "tsc && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/package/src/ShikiHighlighter.tsx
+++ b/package/src/ShikiHighlighter.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 import { useShikiHighlighter } from './useShiki';
 import type { Language, Theme, HighlighterOptions } from './types';
+import type { ShikiTransformer } from 'shiki';
 
 /**
  * Props for the ShikiHighlighter component
@@ -32,6 +33,11 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
    * @default undefined (no delay)
    */
   delay?: number;
+
+  /**
+   * Pass custom Shiki transformers to the highlighter
+   */
+  transformers?: ShikiTransformer[];
 
   /**
    * Controls the application of default styles to the generated code blocks
@@ -93,6 +99,7 @@ export const ShikiHighlighter = ({
   language,
   theme,
   delay,
+  transformers,
   addDefaultStyles = true,
   style,
   langStyle,
@@ -102,7 +109,8 @@ export const ShikiHighlighter = ({
   children: code,
   as: Element = 'pre',
 }: ShikiHighlighterProps): React.ReactElement => {
-  const highlightedCode = useShikiHighlighter(code, language, theme, { delay });
+  const options: HighlighterOptions = { delay, transformers };
+  const highlightedCode = useShikiHighlighter(code, language, theme, options);
 
   return (
     <Element
@@ -117,7 +125,7 @@ export const ShikiHighlighter = ({
     >
       {showLanguage && language ? (
         <span
-          className={clsx('languageLabel', langClassName)} 
+          className={clsx('languageLabel', langClassName)}
           style={langStyle}
           id='language-label'
         >

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -57,8 +57,7 @@ describe('rehypeInlineCodeProperty', () => {
     // Locate the <code> element.
     const codeElement = tree?.children[0]?.children[0];
     expect(codeElement?.tagName).toBe('code');
-    // @ts-ignore
-    expect(codeElement?.properties.inline).toBe(true);
+    expect((codeElement?.properties as { inline: boolean }).inline).toBe(true);
   });
 
   it('does not add the inline property to <code> elements inside <pre>', () => {
@@ -93,7 +92,6 @@ describe('rehypeInlineCodeProperty', () => {
     const codeElement = preElement?.children[0];
     expect(codeElement?.tagName).toBe('code');
     // Since the code element is inside a <pre>, it should not have an inline property.
-    // @ts-ignore
-    expect(codeElement?.properties.inline).toBeUndefined();
+    expect((codeElement?.properties as { inline: boolean }).inline).toBeUndefined();
   });
 });

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -21,8 +21,7 @@ describe('isInlineCode', () => {
         },
       ],
     };
-    // @ts-expect-error
-    expect(isInlineCode(blockNode)).toBe(false);
+    expect(isInlineCode(blockNode as any)).toBe(false);
   });
 });
 
@@ -74,7 +73,7 @@ describe('rehypeInlineCodeProperty', () => {
             {
               type: 'element',
               tagName: 'code',
-              properties: {}, // initially empty
+              properties: {},
               children: [
                 { type: 'text', value: 'block code' },
               ],

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -1,0 +1,99 @@
+// ShikiHighlighter.utils.test.ts
+import { isInlineCode, rehypeInlineCodeProperty } from '../utils';
+
+describe('isInlineCode', () => {
+  it('returns true for inline code (no newline in text)', () => {
+    // Simulate a node representing inline code.
+    const inlineNode = {
+      children: [
+        { type: 'text', value: 'console.log("Hello inline world!");' },
+      ],
+    };
+    expect(isInlineCode(inlineNode as any)).toBe(true);
+  });
+
+  it('returns false for code fences (text contains newline)', () => {
+    // Simulate a node representing block (fenced) code.
+    const blockNode = {
+      children: [
+        {
+          type: 'text',
+          value: 'console.log("Line 1");\nconsole.log("Line 2");',
+        },
+      ],
+    };
+    expect(isInlineCode(blockNode as any)).toBe(false);
+  });
+});
+
+describe('rehypeInlineCodeProperty', () => {
+  it('adds the inline property to <code> elements that are not inside <pre>', () => {
+    // Simulate a tree where a <code> element is inside a <p> (not inside a <pre>).
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {}, // initially empty
+              children: [
+                { type: 'text', value: 'inline code' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Run the plugin.
+    const plugin = rehypeInlineCodeProperty();
+    plugin(tree as any);
+
+    // Locate the <code> element.
+    const codeElement = tree?.children[0]?.children[0];
+    expect(codeElement?.tagName).toBe('code');
+    // @ts-ignore
+    expect(codeElement?.properties.inline).toBe(true);
+  });
+
+  it('does not add the inline property to <code> elements inside <pre>', () => {
+    // Simulate a tree where a <code> element is inside a <pre> element.
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'pre',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {}, // initially empty
+              children: [
+                { type: 'text', value: 'block code' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Run the plugin.
+    const plugin = rehypeInlineCodeProperty();
+    plugin(tree as any);
+
+    // Locate the <code> element inside <pre>.
+    const preElement = tree.children[0];
+    const codeElement = preElement?.children[0];
+    expect(codeElement?.tagName).toBe('code');
+    // Since the code element is inside a <pre>, it should not have an inline property.
+    // @ts-ignore
+    expect(codeElement?.properties.inline).toBeUndefined();
+  });
+});

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -1,9 +1,8 @@
-// ShikiHighlighter.utils.test.ts
 import { isInlineCode, rehypeInlineCodeProperty } from '../utils';
 
 describe('isInlineCode', () => {
   it('returns true for inline code (no newline in text)', () => {
-    // Simulate a node representing inline code.
+    // Mock a node representing inline code.
     const inlineNode = {
       children: [
         { type: 'text', value: 'console.log("Hello inline world!");' },
@@ -13,7 +12,7 @@ describe('isInlineCode', () => {
   });
 
   it('returns false for code fences (text contains newline)', () => {
-    // Simulate a node representing block (fenced) code.
+    // Mock a node representing block (fenced) code.
     const blockNode = {
       children: [
         {
@@ -22,13 +21,14 @@ describe('isInlineCode', () => {
         },
       ],
     };
-    expect(isInlineCode(blockNode as any)).toBe(false);
+    // @ts-expect-error
+    expect(isInlineCode(blockNode)).toBe(false);
   });
 });
 
 describe('rehypeInlineCodeProperty', () => {
   it('adds the inline property to <code> elements that are not inside <pre>', () => {
-    // Simulate a tree where a <code> element is inside a <p> (not inside a <pre>).
+    // Mock a tree where a <code> element is inside a <p>.
     const tree = {
       type: 'root',
       children: [
@@ -40,7 +40,7 @@ describe('rehypeInlineCodeProperty', () => {
             {
               type: 'element',
               tagName: 'code',
-              properties: {}, // initially empty
+              properties: {},
               children: [
                 { type: 'text', value: 'inline code' },
               ],
@@ -57,7 +57,8 @@ describe('rehypeInlineCodeProperty', () => {
     // Locate the <code> element.
     const codeElement = tree?.children[0]?.children[0];
     expect(codeElement?.tagName).toBe('code');
-    expect((codeElement?.properties as { inline: boolean }).inline).toBe(true);
+    // @ts-expect-error
+    expect(codeElement?.properties.inline).toBe(true);
   });
 
   it('does not add the inline property to <code> elements inside <pre>', () => {
@@ -92,6 +93,7 @@ describe('rehypeInlineCodeProperty', () => {
     const codeElement = preElement?.children[0];
     expect(codeElement?.tagName).toBe('code');
     // Since the code element is inside a <pre>, it should not have an inline property.
-    expect((codeElement?.properties as { inline: boolean }).inline).toBeUndefined();
+    // @ts-expect-error
+    expect(codeElement?.properties.inline).toBeUndefined();
   });
 });

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -1,9 +1,4 @@
-import type { 
-  BundledLanguage, 
-  BundledTheme,
-  SpecialLanguage,
-  ThemeRegistration
-} from 'shiki';
+import type { BundledLanguage, BundledTheme, SpecialLanguage, ShikiTransformer, ThemeRegistration } from 'shiki';
 
 /** 
  * Languages for syntax highlighting.
@@ -27,9 +22,14 @@ type Theme = ThemeRegistration | BundledTheme;
 type HighlighterOptions = {
   /** 
    * Minimum time (in milliseconds) between highlight operations. 
-   * Defaults to undefined (no throttling)
+   * @default undefined (no throttling)
    */
   delay?: number;
+
+  /**
+   * Custom Shiki transformers to apply to the highlighted code.
+   */
+  transformers?: ShikiTransformer[];
 };
 
 /**

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -30,6 +30,12 @@ const highlighter = createSingletonShorthands(createHighlighter);
 /**
  * A React hook that provides syntax highlighting using Shiki.
  * Supports optional throttled highlights and custom themes.
+ *
+ * @example
+ * const highlightedCode = useShikiHighlighter(code, language, theme, {
+ *   transformers: [removeTabIndexFromPre],
+ *   delay: 150
+ * });
  */
 export const useShikiHighlighter = (
   code: string,
@@ -48,11 +54,13 @@ export const useShikiHighlighter = (
   useEffect(() => {
     let isMounted = true;
 
+    const transformers = [removeTabIndexFromPre, ...(options.transformers || [])];
+
     const highlightCode = async () => {
       const html = await highlighter.codeToHtml(code, {
         lang: language,
         theme,
-        transformers: [removeTabIndexFromPre],
+        transformers
       });
 
       if (isMounted) {


### PR DESCRIPTION
### TL;DR
Add support for custom Shiki transformers.

### What changed?
- Modified `useShikiHighlighter` to combine custom transformers with the default `removeTabIndexFromPre`
- Added `transformers` option to `HighlighterOptions`
- Import type `ShikiTransformer`

### How to test?
```typescript
const highlightedCode = useShikiHighlighter(code, 'plaintext', theme, {
  transformers: [customTransformer],
  delay: 150
});
```
Verify that:
1. Custom transformers are applied to the highlighted code
2. The default `removeTabIndexFromPre` transformer still works, code blocks should not be focusable
3. No type errors with special languages like plaintext and ansi

### Why make this change?
To provide more flexibility in code highlighting by allowing users to add custom Shiki transformers while maintaining the default tab index removal functionality. This also improves type safety by using the proper `SpecialLanguage` type instead of a hardcoded string.

*PR written with help from graphite AI*