### PR TITLE
chore: Add tests for inline utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "package:build": "pnpm --filter react-shiki build",
     "playground:dev": "pnpm --filter playground dev",
     "playground:build": "pnpm --filter playground build",
+    "test": "pnpm --filter react-shiki test",
     "lint": "tsc && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -57,8 +57,7 @@ describe('rehypeInlineCodeProperty', () => {
     // Locate the <code> element.
     const codeElement = tree?.children[0]?.children[0];
     expect(codeElement?.tagName).toBe('code');
-    // @ts-ignore
-    expect(codeElement?.properties.inline).toBe(true);
+    expect((codeElement?.properties as { inline: boolean }).inline).toBe(true);
   });
 
   it('does not add the inline property to <code> elements inside <pre>', () => {
@@ -93,7 +92,6 @@ describe('rehypeInlineCodeProperty', () => {
     const codeElement = preElement?.children[0];
     expect(codeElement?.tagName).toBe('code');
     // Since the code element is inside a <pre>, it should not have an inline property.
-    // @ts-ignore
-    expect(codeElement?.properties.inline).toBeUndefined();
+    expect((codeElement?.properties as { inline: boolean }).inline).toBeUndefined();
   });
 });

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -21,8 +21,7 @@ describe('isInlineCode', () => {
         },
       ],
     };
-    // @ts-expect-error
-    expect(isInlineCode(blockNode)).toBe(false);
+    expect(isInlineCode(blockNode as any)).toBe(false);
   });
 });
 
@@ -74,7 +73,7 @@ describe('rehypeInlineCodeProperty', () => {
             {
               type: 'element',
               tagName: 'code',
-              properties: {}, // initially empty
+              properties: {},
               children: [
                 { type: 'text', value: 'block code' },
               ],

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -1,0 +1,99 @@
+// ShikiHighlighter.utils.test.ts
+import { isInlineCode, rehypeInlineCodeProperty } from '../utils';
+
+describe('isInlineCode', () => {
+  it('returns true for inline code (no newline in text)', () => {
+    // Simulate a node representing inline code.
+    const inlineNode = {
+      children: [
+        { type: 'text', value: 'console.log("Hello inline world!");' },
+      ],
+    };
+    expect(isInlineCode(inlineNode as any)).toBe(true);
+  });
+
+  it('returns false for code fences (text contains newline)', () => {
+    // Simulate a node representing block (fenced) code.
+    const blockNode = {
+      children: [
+        {
+          type: 'text',
+          value: 'console.log("Line 1");\nconsole.log("Line 2");',
+        },
+      ],
+    };
+    expect(isInlineCode(blockNode as any)).toBe(false);
+  });
+});
+
+describe('rehypeInlineCodeProperty', () => {
+  it('adds the inline property to <code> elements that are not inside <pre>', () => {
+    // Simulate a tree where a <code> element is inside a <p> (not inside a <pre>).
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {}, // initially empty
+              children: [
+                { type: 'text', value: 'inline code' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Run the plugin.
+    const plugin = rehypeInlineCodeProperty();
+    plugin(tree as any);
+
+    // Locate the <code> element.
+    const codeElement = tree?.children[0]?.children[0];
+    expect(codeElement?.tagName).toBe('code');
+    // @ts-ignore
+    expect(codeElement?.properties.inline).toBe(true);
+  });
+
+  it('does not add the inline property to <code> elements inside <pre>', () => {
+    // Simulate a tree where a <code> element is inside a <pre> element.
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'pre',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {}, // initially empty
+              children: [
+                { type: 'text', value: 'block code' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Run the plugin.
+    const plugin = rehypeInlineCodeProperty();
+    plugin(tree as any);
+
+    // Locate the <code> element inside <pre>.
+    const preElement = tree.children[0];
+    const codeElement = preElement?.children[0];
+    expect(codeElement?.tagName).toBe('code');
+    // Since the code element is inside a <pre>, it should not have an inline property.
+    // @ts-ignore
+    expect(codeElement?.properties.inline).toBeUndefined();
+  });
+});

--- a/package/src/__tests__/utils.test.ts
+++ b/package/src/__tests__/utils.test.ts
@@ -1,9 +1,8 @@
-// ShikiHighlighter.utils.test.ts
 import { isInlineCode, rehypeInlineCodeProperty } from '../utils';
 
 describe('isInlineCode', () => {
   it('returns true for inline code (no newline in text)', () => {
-    // Simulate a node representing inline code.
+    // Mock a node representing inline code.
     const inlineNode = {
       children: [
         { type: 'text', value: 'console.log("Hello inline world!");' },
@@ -13,7 +12,7 @@ describe('isInlineCode', () => {
   });
 
   it('returns false for code fences (text contains newline)', () => {
-    // Simulate a node representing block (fenced) code.
+    // Mock a node representing block (fenced) code.
     const blockNode = {
       children: [
         {
@@ -22,13 +21,14 @@ describe('isInlineCode', () => {
         },
       ],
     };
-    expect(isInlineCode(blockNode as any)).toBe(false);
+    // @ts-expect-error
+    expect(isInlineCode(blockNode)).toBe(false);
   });
 });
 
 describe('rehypeInlineCodeProperty', () => {
   it('adds the inline property to <code> elements that are not inside <pre>', () => {
-    // Simulate a tree where a <code> element is inside a <p> (not inside a <pre>).
+    // Mock a tree where a <code> element is inside a <p>.
     const tree = {
       type: 'root',
       children: [
@@ -40,7 +40,7 @@ describe('rehypeInlineCodeProperty', () => {
             {
               type: 'element',
               tagName: 'code',
-              properties: {}, // initially empty
+              properties: {},
               children: [
                 { type: 'text', value: 'inline code' },
               ],
@@ -57,7 +57,8 @@ describe('rehypeInlineCodeProperty', () => {
     // Locate the <code> element.
     const codeElement = tree?.children[0]?.children[0];
     expect(codeElement?.tagName).toBe('code');
-    expect((codeElement?.properties as { inline: boolean }).inline).toBe(true);
+    // @ts-expect-error
+    expect(codeElement?.properties.inline).toBe(true);
   });
 
   it('does not add the inline property to <code> elements inside <pre>', () => {
@@ -92,6 +93,7 @@ describe('rehypeInlineCodeProperty', () => {
     const codeElement = preElement?.children[0];
     expect(codeElement?.tagName).toBe('code');
     // Since the code element is inside a <pre>, it should not have an inline property.
-    expect((codeElement?.properties as { inline: boolean }).inline).toBeUndefined();
+    // @ts-expect-error
+    expect(codeElement?.properties.inline).toBeUndefined();
   });
 });


### PR DESCRIPTION
### TL;DR
Add test coverage for utility functions that handle inline code detection and property assignment in rehype.

### What changed?
- Added test suite for `isInlineCode` function to verify correct detection of inline vs. block code
- Added test suite for `rehypeInlineCodeProperty` plugin to ensure proper property assignment
- Verified that inline code elements receive the `inline: true` property
- Confirmed that code blocks within `<pre>` tags remain unmodified

### How to test?
1. Run the test suite: `pnpm test`
2. Verify that all tests pass for both utility functions
3. Check that inline code detection works with single-line code snippets
4. Confirm that multi-line code blocks are properly identified
5. Validate that the rehype plugin correctly modifies only inline code elements

### Why make this change?
To ensure reliable distinction between inline code and code blocks in the markdown processing pipeline, which is crucial for proper styling and rendering of code elements in the final output.

*PR written by graphite AI*