### PR TITLE
fix: Declare mdx module to avoid import error

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,4 +1,3 @@
-// @ts-ignore: idk why its erroring
 import Demo from './Demo.mdx';
 
 function App() {

--- a/playground/src/mdx.d.ts
+++ b/playground/src/mdx.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx' {
+  let MDXComponent: (props) => JSX.Element;
+  export default MDXComponent;
+}


### PR DESCRIPTION
Added TypeScript declaration for MDX files and removed ts-ignore comment

### What changed?

- Created a new TypeScript declaration file (`mdx.d.ts`) to properly type MDX imports
- Removed the ts-ignore comment from App.tsx as it's no longer needed
