### PR TITLE
chore(ci): Fix workflow, add Node matrix and update pnpm version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [16, 18, 20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup PNPM
-        run: corepack enable && pnpm -v
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20.3
+          node-version: 20.18.2
           cache: pnpm
+
+      - name: Setup PNPM
+        run: corepack enable && pnpm -v
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.4.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,21 +5,28 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20.18.2
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
-      - name: Setup PNPM
-        run: corepack enable && pnpm -v
-
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm --filter react-shiki install --frozen-lockfile
+
 
       - name: Build
         run: pnpm --filter react-shiki build
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [18, 20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "root",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@9.6.0",
   "scripts": {
     "dev": "pnpm --stream -r --parallel dev",
     "build": "pnpm --stream -r --parallel build",
@@ -21,5 +20,6 @@
     "@biomejs/biome": "^1.8.3",
     "@changesets/cli": "^2.27.7",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "pnpm@10.4.0"
 }

--- a/package/package.json
+++ b/package/package.json
@@ -61,6 +61,5 @@
     "jsdom": "^22.1.0",
     "tsup": "^8.2.4",
     "vitest": "^0.34.0"
-  },
-  "packageManager": "pnpm@9.6.0"
+  }
 }


### PR DESCRIPTION
Update CI build workflow to test against multiple Node.js versions and upgrades `pnpm` to `10.4.0`

- Fixes failing `build.yml` workflow
- Adds matrix strategy to test `Node.js` versions `18`, `20`, and `22`
- Uses official `pnpm` GitHub Action instead of manual setup
- Removes redundant `packageManager` field from `package/package.json`
- Upgrades `pnpm` from `9.6.0` to `10.4.0`
