### PR TITLE
fix: Add support for custom textmate grammars

### DIFF
--- a/.changeset/empty-carrots-glow.md
+++ b/.changeset/empty-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": minor
+---
+
+Add support for custom languages

--- a/package/README.md
+++ b/package/README.md
@@ -1,11 +1,12 @@
 # 🎨 [react-shiki](https://npmjs.com/react-shiki)
 
 > [!NOTE]
-> This package is still a work in progress, fully functional but not
-> extensively tested.
+> This library is still in development, more features will 
+> continue to be implemented, and API may change. 
+> Contributions are welcome!
 
 Performant client side syntax highlighting component + hook
-for react using [Shiki](https://shiki.matsu.io/)
+for react built with [Shiki](https://shiki.matsu.io/)
 
 [See the demo page with highlighted code blocks showcasing several Shiki themes!](https://react-shiki.vercel.app/)
 
@@ -18,6 +19,7 @@ for react using [Shiki](https://shiki.matsu.io/)
     - [`react-markdown`](#react-markdown)
     - [Check if code is inline](#check-if-code-is-inline)
     - [Custom themes](#custom-themes)
+    - [Custom languages](#custom-languages)
     - [Custom transformers](#custom-transformers)
   - [Performance](#performance)
     - [Throttling real-time highlighting](#throttling-real-time-highlighting)
@@ -258,7 +260,8 @@ import { customTransformer } from '../utils/shikiTransformers';
 // component
 <ShikiHighlighter
   language="tsx"
-  transformers={[customTransformer]}>
+  transformers={[customTransformer]}
+>
   {String(code).trim()}
 </ShikiHighlighter>;
 

--- a/package/README.md
+++ b/package/README.md
@@ -29,8 +29,7 @@ for react using [Shiki](https://shiki.matsu.io/)
 - 🖼️ Provides a `ShikiHighlighter` component for highlighting code as children,
   as well as a `useShikiHighlighter` hook for more flexibility
 - 🔐 No `dangerouslySetInnerHTML`, output from Shiki is parsed using `html-react-parser`
-- 📦 Supports all Shiki languages and themes
-- 🖌️ Full support for custom TextMate themes in a JavaScript object format
+- 🖌️ Full support for custom TextMate languages and themes
 - 🔧 Supports passing custom Shiki transformers to the highlighter
 - 🚰 Performant highlighting of streamed code on the client, with optional throttling
 - 📚 Includes minimal default styles for code blocks
@@ -161,8 +160,8 @@ import { CodeHighlight } from "./CodeHighlight";
 ### Check if code is inline
 
 There are two ways to check if a code block is inline:
-`react-shiki` exports `isInlineCode`, good but marks multiline inline
-code tags as code blocks.
+`react-shiki` exports `isInlineCode` which parses the `node` 
+prop to determine if the code is inline based on the presence of line breaks:
 
 ```tsx
 const isInline: boolean | undefined = node ? isInlineCode(node) : undefined;
@@ -178,8 +177,9 @@ return !isInline ? (
 );
 ```
 
-`react-shiki` also exports `rehypeInlineCodeProperty`, a more accurate way
-to determine if code is inline.
+`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that adds
+an `inline` property to `react-markdown` to determine if code is inline based on 
+the presence of a `<pre>` tag as a parent of `<code>`.
 It's passed as a rehype plugin to `react-markdown`:
 
 ```tsx
@@ -196,7 +196,7 @@ import { rehypeInlineCodeProperty } from "react-shiki";
 </ReactMarkdown>;
 ```
 
-And can be accessed as a prop:
+Now `inline` can be accessed as a prop in the `CodeHighlight` component:
 
 ```tsx
 const CodeHighlight = ({
@@ -208,11 +208,12 @@ const CodeHighlight = ({
 }: CodeHighlightProps): JSX.Element => {
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
+  const code = String(children).trim();
 
 
 return !inline ? (
   <ShikiHighlighter language={language} theme={"houston"} {...props}>
-    {String(children).trim()}
+    {code}
   </ShikiHighlighter>
 ) : (
   <code className={className} {...props}>
@@ -224,23 +225,45 @@ return !inline ? (
 ### Custom themes
 
 ```tsx
-import tokyoNight from '@styles/tokyo-night.mjs';
+import tokyoNight from '../styles/tokyo-night.mjs';
 
+// component
 <ShikiHighlighter language="tsx" theme={tokyoNight}>
-  {String(code)}
+  {String(code).trim()}
 </ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
+```
+
+### Custom languages
+
+```tsx
+import mcfunction from "../langs/mcfunction.tmLanguage.json"
+
+// component
+<ShikiHighlighter language={mcfunction} theme="github-dark" >
+  {String(code).trim()}
+</ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
 ```
 
 ### Custom transformers
 
 ```tsx
-import { customTransformer } from '@utils/customTransformers';
+import { customTransformer } from '../utils/shikiTransformers';
 
+// component
 <ShikiHighlighter
   language="tsx"
   transformers={[customTransformer]}>
   {String(code).trim()}
 </ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", [customTransformer]);
 ```
 
 ## Performance

--- a/package/README.md
+++ b/package/README.md
@@ -20,6 +20,7 @@ for react built with [Shiki](https://shiki.matsu.io/)
     - [Check if code is inline](#check-if-code-is-inline)
     - [Custom themes](#custom-themes)
     - [Custom languages](#custom-languages)
+      - [Preloading custom languages](#preloading-custom-languages)
     - [Custom transformers](#custom-transformers)
   - [Performance](#performance)
     - [Throttling real-time highlighting](#throttling-real-time-highlighting)
@@ -31,7 +32,8 @@ for react built with [Shiki](https://shiki.matsu.io/)
 - 🖼️ Provides a `ShikiHighlighter` component for highlighting code as children,
   as well as a `useShikiHighlighter` hook for more flexibility
 - 🔐 No `dangerouslySetInnerHTML`, output from Shiki is parsed using `html-react-parser`
-- 🖌️ Full support for custom TextMate languages and themes
+- 📦 Supports all built-in Shiki languages and themes
+- 🖌️ Full support for custom TextMate themes in a JavaScript object format
 - 🔧 Supports passing custom Shiki transformers to the highlighter
 - 🚰 Performant highlighting of streamed code on the client, with optional throttling
 - 📚 Includes minimal default styles for code blocks
@@ -39,13 +41,12 @@ for react built with [Shiki](https://shiki.matsu.io/)
   optimizing for performance
 - 🖥️ `ShikiHighlighter` component displays a language label for each code block
   when `showLanguage` is set to `true` (default)
-- 🎨 Users can customize the styling of the generated code blocks by passing
-  a `style` object or a `className`
+- 🎨 Customizable styling of generated code blocks and language labels
 
 ## Installation
 
 ```bash
-[pnpm|bun|yarn|npm] install react-shiki
+pnpm install react-shiki
 ```
 
 ## Usage
@@ -226,8 +227,10 @@ return !inline ? (
 
 ### Custom themes
 
+Pass custom TextMate themes as a JSON object:
+
 ```tsx
-import tokyoNight from '../styles/tokyo-night.mjs';
+import tokyoNight from '../styles/tokyo-night.json';
 
 // component
 <ShikiHighlighter language="tsx" theme={tokyoNight}>
@@ -240,6 +243,8 @@ const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
 
 ### Custom languages
 
+Pass custom TextMate languages as a JSON object:
+
 ```tsx
 import mcfunction from "../langs/mcfunction.tmLanguage.json"
 
@@ -250,6 +255,22 @@ import mcfunction from "../langs/mcfunction.tmLanguage.json"
 
 // hook
 const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
+```
+#### Preloading custom languages
+
+For dynamic highlighting scenarios (like LLM chat apps) where language selection happens at runtime, preload custom languages to make them available when needed:
+
+```tsx
+import mcfunction from "../langs/mcfunction.tmLanguage.json"
+import bosque from "../langs/bosque.tmLanguage.json"
+
+// component
+<ShikiHighlighter language={mcfunction} theme="github-dark" customLanguages={[mcfunction, bosque]} >
+  {String(code).trim()}
+</ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark", { customLanguages: [mcfunction, bosque] });
 ```
 
 ### Custom transformers

--- a/package/src/ShikiHighlighter.tsx
+++ b/package/src/ShikiHighlighter.tsx
@@ -129,10 +129,8 @@ export const ShikiHighlighter = ({
       : [customLanguages]
     : [];
 
-  const { isCustom, languageId, resolvedLanguage } = resolveLanguage(
-    language,
-    normalizedCustomLanguages
-  );
+  const { isCustom, languageId, displayLanguageId, resolvedLanguage } =
+    resolveLanguage(language, normalizedCustomLanguages);
 
   const highlightedCode = useShikiHighlighter(
     code,
@@ -161,7 +159,7 @@ export const ShikiHighlighter = ({
         >
           {isCustom
             ? `${resolvedLanguage?.scopeName.split('.')[1]}`
-            : languageId}
+            : displayLanguageId || languageId}
         </span>
       ) : null}
       {highlightedCode}

--- a/package/src/ShikiHighlighter.tsx
+++ b/package/src/ShikiHighlighter.tsx
@@ -11,25 +11,25 @@ import type { LanguageRegistration } from './customTypes';
  * Props for the ShikiHighlighter component
  */
 export interface ShikiHighlighterProps extends HighlighterOptions {
-  /** 
+  /**
    * The programming language for syntax highlighting
    * @see https://shiki.style/languages
    */
   language: Language;
 
-  /** 
-   * The code to be highlighted 
+  /**
+   * The code to be highlighted
    */
   children: string;
 
-  /** 
+  /**
    * The color theme for syntax highlighting
    * Supports Shiki and custom textmate themes
    * @see https://shiki.style/themes
    */
   theme: Theme;
 
-  /** 
+  /**
    * The delay in milliseconds between streamed updates
    * Use this when highlighting code being streamed on the client
    * @default undefined (no delay)
@@ -49,33 +49,33 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
    */
   addDefaultStyles?: boolean;
 
-  /** 
-   * Add custom inline styles to the generated code block 
+  /**
+   * Add custom inline styles to the generated code block
    */
   style?: React.CSSProperties;
 
-  /** 
-   * Add custom inline styles to the language label 
+  /**
+   * Add custom inline styles to the language label
    */
   langStyle?: React.CSSProperties;
 
-  /** 
-   * Add custom CSS class names to the generated code block 
+  /**
+   * Add custom CSS class names to the generated code block
    */
   className?: string;
 
-  /** 
-   * Add custom CSS class names to the language label 
+  /**
+   * Add custom CSS class names to the language label
    */
   langClassName?: string;
 
-  /** 
+  /**
    * Whether to show the language label
    * @default true
    */
   showLanguage?: boolean;
 
-  /** 
+  /**
    * The HTML element that wraps the generated code block.
    * @default 'pre'
    */
@@ -93,8 +93,8 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
  *
  * @example
  * ```tsx
- * <ShikiHighlighter 
- *   language="typescript" 
+ * <ShikiHighlighter
+ *   language="typescript"
  *   theme="github-dark"
  *   delay={100} // Optional throttling for streamed updates
  * >
@@ -117,21 +117,30 @@ export const ShikiHighlighter = ({
   as: Element = 'pre',
   customLanguages,
 }: ShikiHighlighterProps): React.ReactElement => {
-    const options: HighlighterOptions = { 
-    delay, 
+  const options: HighlighterOptions = {
+    delay,
     transformers,
     customLanguages,
   };
-  
+
   const normalizedCustomLanguages = customLanguages
     ? Array.isArray(customLanguages)
       ? customLanguages
       : [customLanguages]
     : [];
-  
-  const { languageId, customLanguage, isCustom } = resolveLanguage(language, normalizedCustomLanguages);
-  const highlightedCode = useShikiHighlighter(code, language, theme, options);
-  
+
+  const { isCustom, languageId, resolvedLanguage } = resolveLanguage(
+    language,
+    normalizedCustomLanguages
+  );
+
+  const highlightedCode = useShikiHighlighter(
+    code,
+    language,
+    theme,
+    options
+  );
+
   return (
     <Element
       data-testid="shiki-container"
@@ -142,15 +151,17 @@ export const ShikiHighlighter = ({
         className
       )}
       style={style}
-      id='shiki-container'
+      id="shiki-container"
     >
       {showLanguage && language ? (
         <span
           className={clsx('languageLabel', langClassName)}
           style={langStyle}
-          id='language-label'
+          id="language-label"
         >
-          {isCustom ? `${customLanguage?.scopeName.split('.')[1]}` : languageId}
+          {isCustom
+            ? `${resolvedLanguage?.scopeName.split('.')[1]}`
+            : languageId}
         </span>
       ) : null}
       {highlightedCode}

--- a/package/src/ShikiHighlighter.tsx
+++ b/package/src/ShikiHighlighter.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 import { useShikiHighlighter } from './useShiki';
 import type { Language, Theme, HighlighterOptions } from './types';
 import type { ShikiTransformer } from 'shiki';
+import { resolvedLang } from './utils';
 
 /**
  * Props for the ShikiHighlighter component
@@ -111,6 +112,11 @@ export const ShikiHighlighter = ({
 }: ShikiHighlighterProps): React.ReactElement => {
   const options: HighlighterOptions = { delay, transformers };
   const highlightedCode = useShikiHighlighter(code, language, theme, options);
+  
+  const languageLabel =
+    language && typeof language === 'object'
+      ? resolvedLang(language)
+      : language;
 
   return (
     <Element
@@ -130,7 +136,7 @@ export const ShikiHighlighter = ({
           style={langStyle}
           id='language-label'
         >
-          {language}
+          {languageLabel}
         </span>
       ) : null}
       {highlightedCode}

--- a/package/src/customTypes.ts
+++ b/package/src/customTypes.ts
@@ -1,0 +1,54 @@
+/**
+* Attribution: 
+*  This workaround is was written by github:hippotastic in expressive-code/expressive-code
+*  https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-shiki/src/languages.ts
+*/
+
+import type { 
+  LanguageRegistration as ShikiLanguageRegistration,
+  MaybeGetter,
+  MaybeArray
+} from 'shiki';
+
+// Extract or rebuild non-exported types from Shiki
+type IShikiRawRepository = ShikiLanguageRegistration['repository'];
+type IShikiRawRule = IShikiRawRepository[keyof IShikiRawRepository];
+type ILocation = IShikiRawRepository['$vscodeTextmateLocation'];
+
+interface ILocatable {
+  readonly $vscodeTextmateLocation?: ILocation;
+}
+
+// Define modified versions of internal Shiki types that use our less strict `IRawRule`
+interface IRawRepositoryMap {
+  [name: string]: IRawRule;
+}
+type IRawRepository = IRawRepositoryMap & ILocatable;
+
+interface IRawCapturesMap {
+  [captureId: string]: IRawRule;
+}
+type IRawCaptures = IRawCapturesMap & ILocatable;
+
+// Create our less strict version of Shiki's internal `IRawRule` interface
+interface IRawRule extends Omit<IShikiRawRule, 'applyEndPatternLast' | 'captures' | 'patterns'> {
+  readonly applyEndPatternLast?: boolean | number;
+  readonly captures?: IRawCaptures;
+  readonly comment?: string;
+  readonly patterns?: IRawRule[];
+}
+
+/**
+ * A less strict version of Shiki's `LanguageRegistration` interface that aligns better with
+ * actual grammars found in the wild. This version attempts to reduce the amount
+ * of type errors that would occur when importing and adding external grammars,
+ * while still being supported by the language processing code.
+ */
+export interface LanguageRegistration extends Omit<ShikiLanguageRegistration, 'repository'> {
+  repository?: IRawRepository;
+}
+
+export type LanguageInput = MaybeGetter<MaybeArray<LanguageRegistration>>;
+
+export type { ShikiLanguageRegistration };
+

--- a/package/src/customTypes.ts
+++ b/package/src/customTypes.ts
@@ -1,13 +1,13 @@
 /**
-* Attribution: 
-*  This workaround is was written by github:hippotastic in expressive-code/expressive-code
-*  https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-shiki/src/languages.ts
-*/
+ * Attribution:
+ *  This code was written by github:hippotastic in expressive-code/expressive-code
+ *  https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/plugin-shiki/src/languages.ts
+ */
 
-import type { 
+import type {
   LanguageRegistration as ShikiLanguageRegistration,
   MaybeGetter,
-  MaybeArray
+  MaybeArray,
 } from 'shiki';
 
 // Extract or rebuild non-exported types from Shiki
@@ -31,7 +31,11 @@ interface IRawCapturesMap {
 type IRawCaptures = IRawCapturesMap & ILocatable;
 
 // Create our less strict version of Shiki's internal `IRawRule` interface
-interface IRawRule extends Omit<IShikiRawRule, 'applyEndPatternLast' | 'captures' | 'patterns'> {
+interface IRawRule
+  extends Omit<
+    IShikiRawRule,
+    'applyEndPatternLast' | 'captures' | 'patterns'
+  > {
   readonly applyEndPatternLast?: boolean | number;
   readonly captures?: IRawCaptures;
   readonly comment?: string;
@@ -44,11 +48,11 @@ interface IRawRule extends Omit<IShikiRawRule, 'applyEndPatternLast' | 'captures
  * of type errors that would occur when importing and adding external grammars,
  * while still being supported by the language processing code.
  */
-export interface LanguageRegistration extends Omit<ShikiLanguageRegistration, 'repository'> {
+export interface LanguageRegistration
+  extends Omit<ShikiLanguageRegistration, 'repository'> {
   repository?: IRawRepository;
 }
 
 export type LanguageInput = MaybeGetter<MaybeArray<LanguageRegistration>>;
 
 export type { ShikiLanguageRegistration };
-

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -8,13 +8,12 @@ import type {
 
 import type { LanguageRegistration } from './customTypes';
 
-
-/** 
+/**
  * Languages for syntax highlighting.
  * @see https://shiki.style/languages
  */
 type Language =
-  BundledLanguage
+  | BundledLanguage
   | LanguageRegistration
   | SpecialLanguage
   | (string & {})
@@ -30,8 +29,8 @@ type Theme = ThemeRegistration | BundledTheme;
  * Configuration options for the syntax highlighter
  */
 type HighlighterOptions = {
-  /** 
-   * Minimum time (in milliseconds) between highlight operations. 
+  /**
+   * Minimum time (in milliseconds) between highlight operations.
    * @default undefined (no throttling)
    */
   delay?: number;

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -44,7 +44,7 @@ type HighlighterOptions = {
   /**
    * Custom textmate grammar to be preloaded for highlighting.
    */
-  customLanguage?: LanguageRegistration | LanguageRegistration[];
+  customLanguages?: LanguageRegistration | LanguageRegistration[];
 };
 
 /**

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -38,6 +38,11 @@ type HighlighterOptions = {
    * Custom Shiki transformers to apply to the highlighted code.
    */
   transformers?: ShikiTransformer[];
+
+  /**
+   * Custom textmate grammar to be preloaded for highlighting.
+   */
+  customLanguage?: Language;
 };
 
 /**

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -44,7 +44,7 @@ type HighlighterOptions = {
   /**
    * Custom textmate grammar to be preloaded for highlighting.
    */
-  customLanguage?: LanguageRegistration;
+  customLanguage?: LanguageRegistration | LanguageRegistration[];
 };
 
 /**

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -1,4 +1,11 @@
-import type { BundledLanguage, BundledTheme, SpecialLanguage, ShikiTransformer, ThemeRegistration } from 'shiki';
+import type {
+  BundledLanguage,
+  SpecialLanguage,
+  LanguageRegistration,
+  BundledTheme,
+  ThemeRegistration,
+  ShikiTransformer,
+} from 'shiki';
 
 /** 
  * Languages for syntax highlighting.
@@ -6,6 +13,7 @@ import type { BundledLanguage, BundledTheme, SpecialLanguage, ShikiTransformer, 
  */
 type Language =
   BundledLanguage
+  | LanguageRegistration
   | SpecialLanguage
   | (string & {})
   | undefined;

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -1,11 +1,13 @@
 import type {
   BundledLanguage,
   SpecialLanguage,
-  LanguageRegistration,
   BundledTheme,
   ThemeRegistration,
   ShikiTransformer,
 } from 'shiki';
+
+import type { LanguageRegistration } from './customTypes';
+
 
 /** 
  * Languages for syntax highlighting.
@@ -42,7 +44,7 @@ type HighlighterOptions = {
   /**
    * Custom textmate grammar to be preloaded for highlighting.
    */
-  customLanguage?: Language;
+  customLanguage?: LanguageRegistration;
 };
 
 /**

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -50,26 +50,27 @@ export const useShikiHighlighter = (
 ) => {
   const [highlightedCode, setHighlightedCode] = useState<ReactNode | null>(null);
 
-const preloadedCustomLang = options.customLanguage as LanguageRegistration | undefined;
-// Only use the preloaded custom language if:
-// - lang is an object (already custom) OR
-// - lang is a string and matches one of customLang.fileTypes (if available)
-// Check if custom language is preloaded by checking lang type and fileTypes match
-const useCustomPreloadedLang = Boolean(
-  preloadedCustomLang
-  && (typeof lang === 'object'
-    || (typeof lang === 'string' && Array.isArray(preloadedCustomLang.fileTypes)
-      && preloadedCustomLang.fileTypes?.includes(lang)
-    )
-  )
-);
-// Otherwise, if lang is an object and no customLanguage was passed, treat it as a custom language.
-const isCustom = !useCustomPreloadedLang && lang && typeof lang === 'object';
+  const preloadedCustomLang = options.customLanguage as LanguageRegistration | undefined;
 
-const timeoutControl = useRef<TimeoutState>({
-  nextAllowedTime: 0,
-  timeoutId: undefined,
-});
+  // Use the preloaded custom language if:
+  // - lang is an object (already custom) OR
+  // - lang is a string and matches one of preloadedCustomLang.fileTypes
+  const useCustomPreloadedLang = Boolean(
+    preloadedCustomLang != null 
+      && ( typeof lang === 'object' 
+        || ( typeof lang === 'string'
+          && Array.isArray(preloadedCustomLang.fileTypes)
+          && preloadedCustomLang.fileTypes.includes(lang)
+      )
+    )
+  );
+  // Otherwise, if lang is an object and no customLanguage was passed, treat it as a custom language.
+  const useCustomLang = !useCustomPreloadedLang && lang && typeof lang === 'object';
+
+  const timeoutControl = useRef<TimeoutState>({
+    nextAllowedTime: 0,
+    timeoutId: undefined,
+  });
 
   // Retrieve or create a cached highlighter with customLang
   const getCachedCustomHighlighter = async (cacheKey: string, customLang: LanguageRegistration | typeof lang) => {
@@ -99,7 +100,7 @@ const timeoutControl = useRef<TimeoutState>({
           theme,
           transformers,
         });
-      } else if (isCustom && !preloadedCustomLang) {
+      } else if (useCustomLang) {
         const cacheKey = `${lang.name}-${theme}`;
         const instance = await getCachedCustomHighlighter(cacheKey, lang);
         html = instance.codeToHtml(code, {

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -57,6 +57,15 @@ export const useShikiHighlighter = (
     const transformers = [removeTabIndexFromPre, ...(options.transformers || [])];
 
     const highlightCode = async () => {
+      // If provided, load custom language after highlighter is initialized
+      if (typeof lang === 'object' && lang !== null && 'id' in lang) {
+        const shikiInstance = await highlighter.getSingletonHighlighter({
+          langs: [language],
+          themes: [theme],
+        });
+        await shikiInstance.loadLanguage(lang);
+      }
+
       const html = await highlighter.codeToHtml(code, {
         lang: language,
         theme,

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -53,32 +53,52 @@ export const useShikiHighlighter = (
   options: HighlighterOptions = {}
 ) => {
   const [highlightedCode, setHighlightedCode] = useState<ReactNode | null>(null);
+  console.log('useShikiHighlighter hook initialized');
 
-  const preloadedCustomLang = options.customLanguage;
+  // const preloadedCustomLang = options.customLanguage as LanguageRegistration | undefined;
 
   // Use the preloaded custom language if
   // = lang is preloaded AND
   // - lang is an object (already custom) OR
   // - lang is a string and matches one of preloadedCustomLang.fileTypes
-  const useCustomPreloadedLang = Boolean(
-    preloadedCustomLang != null
-    && (typeof lang === 'object'
-      || (typeof lang === 'string'
-        && Array.isArray(preloadedCustomLang.fileTypes)
-        && preloadedCustomLang.fileTypes.includes(lang)
-      )
-    )
-  );
+  // const useCustomPreloadedLang = Boolean(
+  //   preloadedCustomLang != null
+  //   && (typeof lang === 'object'
+  //     || (typeof lang === 'string'
+  //       && Array.isArray(preloadedCustomLang.fileTypes)
+  //       && preloadedCustomLang.fileTypes.includes(lang)
+  //     )
+  //   )
+  // );
 
   // Otherwise, use the custom language directly from the lang prop
-  const useCustomLang = !useCustomPreloadedLang && lang && typeof lang === 'object';
+  // const useCustomLang = !useCustomPreloadedLang && lang && typeof lang === 'object';
+  //
+  // const customLang = useCustomPreloadedLang
+  //   ? preloadedCustomLang
+  //   : useCustomLang
+  //     ? lang
+  //     : undefined;
 
-  const customLang = useCustomPreloadedLang
-    ? preloadedCustomLang
-    : useCustomLang
-      ? lang
-      : undefined;
+  // Normalize customLanguage to always be an array.
+  const customLangArray: LanguageRegistration[] = options.customLanguage
+    ? Array.isArray(options.customLanguage)
+      ? options.customLanguage
+      : [options.customLanguage]
+    : [];
 
+  // Choose the matching custom language:
+  const customLang: LanguageRegistration | undefined =
+    typeof lang === 'string'
+      ? customLangArray.find(cl =>
+        (cl.fileTypes && cl.fileTypes.includes(lang)) ||
+        (cl.scopeName && cl.scopeName.split('.')[1] === lang) ||
+        // and if the lang.name === lang
+        (cl.name && cl.name === lang)
+      )
+      : (lang && typeof lang === 'object' ? lang as LanguageRegistration : undefined);
+
+  console.log('Resolved customLang:', customLang, lang);
   const timeoutControl = useRef<TimeoutState>({
     nextAllowedTime: 0,
     timeoutId: undefined,

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -61,30 +61,30 @@ export const useShikiHighlighter = (
       let html: string;
 
       if (isCustom) {
-        // Build an alias mapping from all declared file types to the custom language's original name.
-        const aliasMapping = ((lang as any).fileTypes || []).reduce((acc: Record<string, string>, ft: string) => {
-          acc[ft] = (lang as any).name;
-          return acc;
-        }, {} as Record<string, string>);
+        // Build an alias mapping from lang objects fileTypes to it's original name.
+        // This ensure that shiki can reference the custom language by its fileTypes.
+        // const aliasMapping = (lang.fileTypes || []).reduce(
+        //   (acc: Record<string, string>, ft: string) => {
+        //     acc[ft] = lang.name;
+        //     return acc;
+        //   },
+        //   {} as Record<string, string>
+        // );
 
-        // Create a fresh highlighter instance with our alias mapping.
+        // Create a fresh highlighter instance with the custom language passed directly.
+        // This is necessary because we cannot add an alias mapping to an already created highlighter.
         const shikiInstance = await createHighlighter({
-          langs: [],
+          langs: [lang], // pass the custom language object when creating highlighter
           themes: [theme],
-          langAlias: aliasMapping,
+          // langAlias: aliasMapping, 
         });
-        try {
-          await shikiInstance.loadLanguage(lang);
-        } catch (err) {
-          console.error('[highlightCode] Error loading custom language:', err);
-        }
         html = shikiInstance.codeToHtml(code, {
           lang: lang.name,
           theme,
           transformers,
         });
       } else {
-        // Bundled languages: use the cached singleton instance (with automatic loading).
+        // Bundled languages: use the cached singleton instance.
         html = await highlighter.codeToHtml(code, {
           lang: resolvedLang(lang),
           theme,

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -63,7 +63,7 @@ export const useShikiHighlighter = (
       : [options.customLanguages]
     : [];
 
-const { isCustom, languageId, customLanguage } = resolveLanguage(lang, normalizedCustomLanguages);
+  const { isCustom, languageId, customLanguage } = resolveLanguage(lang, normalizedCustomLanguages);
 
   const timeoutControl = useRef<TimeoutState>({
     nextAllowedTime: 0,
@@ -91,26 +91,16 @@ const { isCustom, languageId, customLanguage } = resolveLanguage(lang, normalize
     const transformers = [removeTabIndexFromPre, ...(options.transformers || [])];
 
     const highlightCode = async () => {
-      let html: string;
+      const codeHighlighter = isCustom && customLanguage
+        ? await getCachedCustomHighlighter(`${customLanguage.name}--${themeKey}`, customLanguage)
+        : highlighter;
 
-      if (isCustom && customLanguage) {
-        const cacheKey = `${customLanguage.name}--${themeKey}`;
-        const customLangHighlighter = await getCachedCustomHighlighter(cacheKey, customLanguage);
-
-        html = customLangHighlighter.codeToHtml(code, {
-          lang: languageId,
-          theme,
-          transformers,
-        });
-
-      } else {
-
-        html = await highlighter.codeToHtml(code, {
-          lang: languageId,
-          theme,
-          transformers,
-        });
-      }
+      // Use the selected highlighter with consistent parameters
+      const html = await codeHighlighter.codeToHtml(code, {
+        lang: languageId,
+        theme,
+        transformers,
+      });
 
       if (isMounted) {
         setHighlightedCode(parse(html));

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -1,6 +1,6 @@
 import { visit } from 'unist-util-visit';
 import { bundledLanguages, isSpecialLang, } from 'shiki';
-import type { BundledLanguage, ShikiTransformer } from 'shiki';
+import type { ShikiTransformer } from 'shiki';
 import type { Element, Root } from 'hast';
 import type { Language, TimeoutState } from './types';
 
@@ -88,7 +88,7 @@ export const throttleHighlighting = (
  */
 export const resolvedLang = (lang: Language): string => {
   if (typeof lang === 'string' && (lang in bundledLanguages || isSpecialLang(lang))) return lang;
-  if (typeof lang === 'object' && lang?.name && typeof lang.name === 'string') return lang.name;
+  if (typeof lang === 'object' && 'name' in lang && typeof lang.name === 'string') return lang.name;
   return 'plaintext';
 };
 

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -80,20 +80,17 @@ export const throttleHighlighting = (
 };
 
 /**
- * Resolve the requested language to a bundled language.
- * If the language is not special or not included in Shiki’s bundledLanguages,
- * fall back to "plaintext".
+ * Resolve the requested language to a bundled language
+ * or the language name from a custom language object.
+ * Fall back to "plaintext" if the language is not bundled or special.
  *
- * @returns {BundledLanguage} The resolved language.
+ * @returns The resolved language.
  */
-export const resolvedLang = (lang: Language): BundledLanguage => {
-  if (typeof lang === 'string') {
-    if (!(lang in bundledLanguages) && !isSpecialLang(lang)) {
-      return 'plaintext' as BundledLanguage;
-    }
-    return lang as BundledLanguage;
-  }
-  return lang as Language as BundledLanguage;
+export const resolvedLang = (lang: Language): string => {
+  if (typeof lang === 'string' && (lang in bundledLanguages || isSpecialLang(lang))) return lang;
+  if (typeof lang === 'object' && lang?.name && typeof lang.name === 'string') return lang.name;
+  return 'plaintext';
 };
+
 
 export type { Element };

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -11,11 +11,11 @@ import type { LanguageRegistration } from './customTypes';
 export type { Element };
 
 /**
- * Rehype plugin to add an 'inline' property to <code> elements.
- * Sets 'inline' property to true if the <code> is not within a <pre> tag.
+ * Rehype plugin to add an 'inline' property to <code> elements
+ * Sets 'inline' property to true if the <code> is not within a <pre> tag
  *
- * Pass this plugin to the `rehypePlugins` prop of ReactMarkdown.
- * You can then access `inline` as a prop from ReactMarkdown.
+ * Pass this plugin to the `rehypePlugins` prop of react-markdown
+ * You can then access `inline` as a prop in components passed to react-markdown
  *
  * @example
  * <ReactMarkdown rehypePlugins={[rehypeInlineCodeProperty]} />
@@ -35,7 +35,7 @@ export function rehypeInlineCodeProperty() {
 }
 
 /**
- * Function to determine if code is inline based on the presence of line breaks.
+ * Function to determine if code is inline based on the presence of line breaks
  *
  * @example
  * const isInline = node && isInlineCode(node: Element)
@@ -50,11 +50,9 @@ export const isInlineCode = (node: Element): boolean => {
 };
 
 /**
- * Shiki transformer to remove tabindex from <pre> elements.
+ * Shiki transformer to remove tabindex from <pre> elements
  *
- * This will be removed in the future to comply with
- * WCAG 2.1 guidelines - .
- * Consider retaining tabindex for WCAG 2.1 compliance, scrollable code blocks should be focusable
+ * Consider retaining tabindex for WCAG 3.1 compliance, scrollable code blocks should be focusable
  *   https://github.com/shikijs/shiki/issues/428
  *   https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/proposed/
  */
@@ -68,7 +66,7 @@ export const removeTabIndexFromPre: ShikiTransformer = {
 };
 
 /**
- * Optionally throttles rapid sequential highlighting operations.
+ * Optionally throttles rapid sequential highlighting operations
  * Exported for testing in __tests__/throttleHighlighting.test.ts
  *
  * @example
@@ -97,6 +95,7 @@ export const throttleHighlighting = (
 type ResolvedLanguage = {
   isCustom: boolean;
   languageId: string;
+  displayLanguageId?: string;
   resolvedLanguage?: LanguageRegistration;
 };
 
@@ -121,18 +120,25 @@ export const resolveLanguage = (
     return {
       isCustom: true,
       languageId: lang.name,
+      displayLanguageId: lang.name,
       resolvedLanguage: lang,
     };
   }
 
-  // Language is string and
+  // Language is a string
   if (typeof lang === 'string') {
-    // is built-in
+    const displayLanguageId = lang;
+
+    // Check if its built-in
     if (lang in bundledLanguages || isSpecialLang(lang)) {
-      return { isCustom: false, languageId: lang };
+      return {
+        isCustom: false,
+        languageId: lang,
+        displayLanguageId,
+      };
     }
 
-    // matches a preloaded custom language
+    // Check if it matches a preloaded custom language
     const customMatch = customLanguages.find(
       (cl) =>
         cl.fileTypes?.includes(lang) ||
@@ -144,11 +150,23 @@ export const resolveLanguage = (
       return {
         isCustom: true,
         languageId: customMatch.name,
+        displayLanguageId,
         resolvedLanguage: customMatch,
       };
     }
+
+    // If unknown, highlight in plaintext but display unknown language
+    return {
+      isCustom: false,
+      languageId: 'plaintext',
+      displayLanguageId,
+    };
   }
 
-  // Fallback to plaintext if no matches
-  return { isCustom: false, languageId: 'plaintext' };
+  // Fallback
+  return {
+    isCustom: false,
+    languageId: 'plaintext',
+    displayLanguageId: 'plaintext',
+  };
 };

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -1,5 +1,6 @@
 import ShikiHighlighter from 'react-shiki';
 import mcfunction from './assets/mcfunction.tmLanguage.json';
+import bosque from './assets/bosque.tmLanguage.json';
 
 # 🎨 react-shiki
 
@@ -263,6 +264,28 @@ const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
     tag @s add isBad
     tag @s remove isBad
     execute if entity @s[tag=isBad] run say he is bad
+  `.trim()}
+</ShikiHighlighter>
+
+**Bosque**:
+<ShikiHighlighter language={bosque} theme="rose-pine">
+  {`
+    function sign(x?: Int=0i): Int {
+        var y: Int;
+
+        if(x == 0i) {
+            y = 0i;
+        }
+        else {
+            y = (x > 0i) ? 1i : -1i;
+        }
+
+        return y;
+    }
+
+    sign(5i)    //1
+    sign(-5i)   //-1
+    sign()     //0
   `.trim()}
 </ShikiHighlighter>
 

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -12,7 +12,8 @@ for react using [Shiki](https://shiki.matsu.io/)
 - 🖼️ Provides a `ShikiHighlighter` component for highlighting code as children,
   as well as a `useShikiHighlighter` hook for more flexibility
 - 🔐 No `dangerouslySetInnerHTML`, output from Shiki is parsed using `html-react-parser`
-- 🖌️ Full support for custom TextMate languages and themes
+- 📦 Supports all built-in Shiki languages and themes
+- 🖌️ Full support for custom TextMate themes in a JavaScript object format
 - 🔧 Supports passing custom Shiki transformers to the highlighter
 - 🚰 Performant highlighting of streamed code on the client, with optional throttling
 - 📚 Includes minimal default styles for code blocks
@@ -20,13 +21,12 @@ for react using [Shiki](https://shiki.matsu.io/)
   optimizing for performance
 - 🖥️ `ShikiHighlighter` component displays a language label for each code block
   when `showLanguage` is set to `true` (default)
-- 🎨 Users can customize the styling of the generated code blocks by passing
-  a `style` object or a `className`
+- 🎨 Customizable styling of generated code blocks and language labels
 
 ## Installation
 
 <ShikiHighlighter language="bash" theme="tokyo-night">
-{`[pnpm|bun|yarn|npm] install react-shiki`}
+{`pnpm install react-shiki`}
 </ShikiHighlighter>
 
 ## Usage
@@ -221,6 +221,7 @@ And can be accessed as a prop:
 </ShikiHighlighter>
 
 ### Custom themes
+Pass custom TextMate themes as a JSON object:
 
 <ShikiHighlighter language="tsx" theme="snazzy-light">
 {`
@@ -237,6 +238,7 @@ const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
 </ShikiHighlighter>
 
 ### Custom languages
+Pass custom TextMate languages as a JSON object:
 
 <ShikiHighlighter language="tsx" theme="github-dark">
 {`
@@ -287,6 +289,25 @@ const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
     sign(-5i)   //-1
     sign()     //0
   `.trim()}
+</ShikiHighlighter>
+
+#### Preloading custom languages
+For dynamic highlighting scenarios (like LLM chat apps) where language selection 
+happens at runtime, preload custom languages to make them available when needed:
+
+<ShikiHighlighter language="tsx" theme="github-dark">
+{`
+import mcfunction from "../langs/mcfunction.tmLanguage.json"
+import bosque from "../langs/bosque.tmLanguage.json"
+
+// component
+<ShikiHighlighter language={mcfunction} theme="github-dark" customLanguages={[mcfunction, bosque]} >
+    {String(code).trim()}
+</ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark", { customLanguages: [mcfunction, bosque] });
+`.trim()}
 </ShikiHighlighter>
 
 ### Custom transformers

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -10,8 +10,7 @@ for react using [Shiki](https://shiki.matsu.io/)
 - 🖼️ Provides a `ShikiHighlighter` component for highlighting code as children,
   as well as a `useShikiHighlighter` hook for more flexibility
 - 🔐 No `dangerouslySetInnerHTML`, output from Shiki is parsed using `html-react-parser`
-- 📦 Supports all Shiki languages and themes
-- 🖌️ Full support for custom TextMate themes in a JavaScript object format
+- 🖌️ Full support for custom TextMate languages and themes
 - 🔧 Supports passing custom Shiki transformers to the highlighter
 - 🚰 Performant highlighting of streamed code on the client, with optional throttling
 - 📚 Includes minimal default styles for code blocks
@@ -152,8 +151,9 @@ import { CodeHighlight } from "./CodeHighlight";
 
 ### Check if code is inline
 
-There are two ways to check if a code block is inline:  
-`react-shiki` exports `isInlineCode`, good but marks multiline inline code tags as code blocks.
+There are two ways to check if a code block is inline:
+`react-shiki` exports `isInlineCode` which parses the `node` 
+prop to determine if the code is inline based on the presence of line breaks:
 
 <ShikiHighlighter language="tsx" theme="material-theme-ocean">
 {`
@@ -171,8 +171,9 @@ There are two ways to check if a code block is inline:
 `.trim()}
 </ShikiHighlighter>
 
-`react-shiki` also exports `rehypeInlineCodeProperty`, a more accurate way
-to determine if code is inline.
+`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that adds
+an `inline` property to `react-markdown` to determine if code is inline based on 
+the presence of a `<pre>` tag as a parent of `<code>`.
 It's passed as a rehype plugin to `react-markdown`:
 
 <ShikiHighlighter language="tsx" theme="catppuccin-latte">
@@ -221,11 +222,31 @@ And can be accessed as a prop:
 
 <ShikiHighlighter language="tsx" theme="snazzy-light">
 {`
-import tokyoNight from '@styles/tokyo-night.mjs';
+import tokyoNight from '../styles/tokyo-night.mjs';
 
+// component
 <ShikiHighlighter language="tsx" theme={tokyoNight}>
     {String(code).trim()}
 </ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
+`.trim()}
+</ShikiHighlighter>
+
+### Custom languages
+
+<ShikiHighlighter language="tsx" theme="github-dark">
+{`
+import mcfunction from "../langs/mcfunction.tmLanguage.json"
+
+// component
+<ShikiHighlighter language={mcfunction} theme="github-dark" >
+    {String(code).trim()}
+</ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
 `.trim()}
 </ShikiHighlighter>
 
@@ -234,12 +255,18 @@ import tokyoNight from '@styles/tokyo-night.mjs';
 
 <ShikiHighlighter language="tsx" theme="snazzy-light">
 {`
-import { customTransformer } from '@utils/customTransformers';
+import { customTransformer } from '../utils/shikiTransformers';
+
+// component
 <ShikiHighlighter
-  language="tsx"
-  transformers={[customTransformer]}>
-  {String(code).trim()}
+   language="tsx"
+   transformers={[customTransformer]}
+>
+   {String(code).trim()}
 </ShikiHighlighter>;
+
+// hook
+const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", [customTransformer]);
 `}
 </ShikiHighlighter>
 

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -1,4 +1,5 @@
 import ShikiHighlighter from 'react-shiki';
+import mcfunction from './assets/mcfunction.tmLanguage.json';
 
 # 🎨 react-shiki
 
@@ -40,7 +41,7 @@ code.
 <ShikiHighlighter language="tsx" theme="ayu-dark">
 {`
 const highlightedCode = useShikiHighlighter(code, language, theme, options);
-`}
+`.trim()}
 </ShikiHighlighter>
 
 The `ShikiHighlighter` component is imported in your project, with the code to
@@ -248,6 +249,21 @@ import mcfunction from "../langs/mcfunction.tmLanguage.json"
 // hook
 const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
 `.trim()}
+</ShikiHighlighter>
+
+### Custom language examples
+
+**Mcfunction**:
+<ShikiHighlighter language={mcfunction} theme="rose-pine-moon" >
+  {`
+    tag @e[tag=mcscriptTags] add isCool
+    tag @e[tag=mcscriptTags] remove isCool
+    execute if entity @e[tag=mcscriptTags,tag=isCool] run say he is cool
+
+    tag @s add isBad
+    tag @s remove isBad
+    execute if entity @s[tag=isBad] run say he is bad
+  `.trim()}
 </ShikiHighlighter>
 
 ### Custom transformers

--- a/playground/src/assets/bosque.tmLanguage.json
+++ b/playground/src/assets/bosque.tmLanguage.json
@@ -1,0 +1,151 @@
+{
+	"name": "Bosque",
+	"patterns": [
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#string-double"
+		},
+		{
+			"include": "#string-single"
+		},
+		{
+			"include": "#constants"
+		},
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#types"
+		},
+		{
+			"include": "#variables"
+		}
+	],
+	"repository": {
+		"comments": {
+			"patterns": [
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.bosque"
+						}
+					},
+					"begin": "//",
+					"end": "$",
+					"name": "comment.line.double-dash.bosque"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.bosque"
+						}
+					},
+					"begin": "/\\*",
+					"end": "\\*/",
+					"name": "comment.multiline.double-dash.bosque"
+				}
+			]
+		},
+		"string-double": {
+			"name": "string.quoted.double.bosque",
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.bosque"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.bosque"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.bosque",
+					"match": "\\\\."
+				}
+			]
+		},
+		"string-single": {
+			"name": "string.quoted.single.bosque",
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.bosque"
+				}
+			},
+			"end": "'",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.bosque"
+				}
+			},
+			"patterns": [
+				{
+					"name": "constant.character.escape.bosque",
+					"match": "\\\\."
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.bosque",
+					"match": "\\b(#if|#else|#endif|_debug|abort|assert|elif|else|ensures|if|invariant|match|release|return|requires|spec|doc|switch|debug|test|validate|yield)\\b"
+				},
+				{
+					"name": "keyword.bosque",
+					"match": "\\b(#if|#else|#endif|recursive?|recursive|_debug|abort|assert|astype|concept|const|elif|else|enum|entity|ensures|err|field|fn|pred|function|if|import|invariant|istype|let|match|method|namespace|of|ok|operator|provides|ref|out|out?|release|return|requires|something|spec|doc|switch|debug|test|type|typedef|typedecl|datatype|using|validate|var|when|yield)\\b"
+				}
+			]
+		},
+		"constants": {
+			"patterns": [
+				{
+					"name": "constant.numeric.bosque",
+					"match": "\\b((0|[1-9][0-9]*)_([A-Z][_a-zA-Z0-9]+))|(0|[1-9][0-9]*)/(0|[1-9][0-9]*)(_([A-Z][_a-zA-Z0-9]+))|([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][-+]?[0-9]+)?(_([A-Z][_a-zA-Z0-9]+))\\b"
+				},
+				{
+					"name": "constant.numeric.bosque",
+					"match": "\\b((0|[1-9][0-9]*)(n|i|N|I))|((0|[1-9][0-9]*)/(0|[1-9][0-9]*)R)|(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][-+]?[0-9]+)?(f|d))\\b"
+				},
+				{
+					"name": "constant.numeric.bosque",
+					"match": "\\b(0|[1-9][0-9]*)|((0|[1-9][0-9]*)/(0|[1-9][0-9]*))|(([0-9]+(\\.[0-9]+)?|\\.[0-9]+)([eE][-+]?[0-9]+)?)\\b"
+				},
+				{
+					"name": "constant.language",
+					"match": "\\b(none|nothing|true|false)\\b"
+				}
+			]
+		},
+		"types": {
+			"patterns": [
+				{
+					"name": "entity.name.type.bosque",
+					"match": "\\b((([A-Z][_a-zA-Z0-9]+)::)*([A-Z][_a-zA-Z0-9]+))\\b"
+				},
+				{
+					"name": "entity.name.type.bosque",
+					"match": "\\b[A-Z]\\b"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"name": "variable.name",
+					"match": "\\b(%([_a-z]|([_a-z][_a-zA-Z0-9]+))%)\\b"
+				},
+				{
+					"name": "variable.name",
+					"match": "\\b([$]?([_a-z]|([_a-z][_a-zA-Z0-9]+)))\\b"
+				}
+			]
+		}
+	},
+	"scopeName": "source.bsq"
+}

--- a/playground/src/assets/mcfunction.tmLanguage.json
+++ b/playground/src/assets/mcfunction.tmLanguage.json
@@ -1,0 +1,740 @@
+{
+  "name": "Syntax Mcfunction",
+  "scopeName": "source.mcfunction",
+  "uuid": "8918dadd-8ebe-42d9-b1e9-0489ab228d9d",
+  "fileTypes": [
+    "mcfunction",
+    "bolt"
+  ],
+  "patterns": [
+    {
+      "include": "#root"
+    }
+  ],
+  "repository": {
+    "root": {
+      "patterns": [
+        {
+          "include": "#literals"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#say"
+        },
+        {
+          "include": "#names"
+        },
+        {
+          "include": "#comments_inline"
+        },
+        {
+          "include": "#subcommands"
+        },
+        {
+          "include": "#property"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#selectors"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "applyEndPatternLast": 1,
+          "begin": "^\\s*(#[>!#])(.+)$",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.block.mcfunction"
+            },
+            "2": {
+              "name": "markup.bold.mcfunction"
+            }
+          },
+          "captures": {
+            "0": {
+              "name": "comment.block.mcfunction"
+            }
+          },
+          "end": "^(?!#)",
+          "name": "meta.comments",
+          "patterns": [
+            {
+              "include": "#comments_block"
+            }
+          ]
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "comment.line.mcfunction"
+            }
+          },
+          "match": "^\\s*#.*$",
+          "name": "meta.comments"
+        }
+      ]
+    },
+    "comments_inline": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "comment.line.mcfunction"
+            }
+          },
+          "match": "#.*$",
+          "name": "meta.comments"
+        }
+      ]
+    },
+    "comments_block": {
+      "patterns": [
+        {
+          "applyEndPatternLast": 1,
+          "begin": "^\\s*#[>!]",
+          "captures": {
+            "0": {
+              "name": "comment.block.mcfunction"
+            }
+          },
+          "end": "$",
+          "name": "meta.comments_block",
+          "patterns": [
+            {
+              "include": "#comments_block_emphasized"
+            }
+          ]
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "^\\s*#",
+          "captures": {
+            "0": {
+              "name": "comment.block.mcfunction"
+            }
+          },
+          "end": "$",
+          "name": "meta.comments_block",
+          "patterns": [
+            {
+              "include": "#comments_block_normal"
+            }
+          ]
+        }
+      ]
+    },
+    "comments_block_emphasized": {
+      "patterns": [
+        {
+          "include": "#comments_block_special"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "markup.bold.mcfunction"
+            }
+          },
+          "match": "\\S+",
+          "name": "meta.comments_block_emphasized"
+        }
+      ]
+    },
+    "comments_block_normal": {
+      "patterns": [
+        {
+          "include": "#comments_block_special"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "comment.block.mcfunction"
+            }
+          },
+          "match": "\\S+",
+          "name": "meta.comments_block_normal"
+        },
+        {
+          "include": "#whitespace"
+        }
+      ]
+    },
+    "comments_block_special": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "markup.heading.mcfunction"
+            }
+          },
+          "match": "@\\S+",
+          "name": "meta.comments_block_special"
+        },
+        {
+          "include": "#resource-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "[#%$][A-Za-z0-9_.#%$]+",
+          "name": "meta.comments_block_special"
+        }
+      ]
+    },
+    "literals": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "constant.numeric.boolean.mcfunction"
+            }
+          },
+          "match": "\\b(true|false|True|False)\\b",
+          "name": "meta.literals"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.uuid.mcfunction"
+            }
+          },
+          "match": "\\b[0-9a-fA-F]+(?:-[0-9a-fA-F]+){4}\\b",
+          "name": "meta.names"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "constant.numeric.float.mcfunction"
+            }
+          },
+          "match": "[+-]?\\d*\\.?\\d+([eE]?[+-]?\\d+)?[df]?\\b",
+          "name": "meta.literals"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "constant.numeric.integer.mcfunction"
+            }
+          },
+          "match": "[+-]?\\d+(b|B|L|l|s|S)?\\b",
+          "name": "meta.literals"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "\\.\\.",
+          "name": "meta.ellipse.literals"
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.mcfunction"
+            }
+          },
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.mcfunction"
+            }
+          },
+          "name": "string.quoted.double.mcfunction",
+          "patterns": [
+            {
+              "include": "#literals_string-double"
+            }
+          ]
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.mcfunction"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.mcfunction"
+            }
+          },
+          "name": "string.quoted.single.mcfunction",
+          "patterns": [
+            {
+              "include": "#literals_string-single"
+            }
+          ]
+        }
+      ]
+    },
+    "subcommands": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "entity.name.class.mcfunction"
+            }
+          },
+          "match": "[a-z_]+",
+          "name": "meta.literals"
+        }
+      ]
+    },
+    "literals_string-double": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "constant.character.escape.mcfunction"
+            }
+          },
+          "match": "\\\\.",
+          "name": "meta.literals_string-double"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "constant.character.escape.mcfunction"
+            }
+          },
+          "match": "\\\\",
+          "name": "meta.literals_string-double"
+        },
+        {
+          "include": "#macro-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "string.quoted.double.mcfunction"
+            }
+          },
+          "match": "[^\\\\\"]",
+          "name": "meta.literals_string-double"
+        }
+      ]
+    },
+    "literals_string-single": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "constant.character.escape.mcfunction"
+            }
+          },
+          "match": "\\\\.",
+          "name": "meta.literals_string-single"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "constant.character.escape.mcfunction"
+            }
+          },
+          "match": "\\\\",
+          "name": "meta.literals_string-double"
+        },
+        {
+          "include": "#macro-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "string.quoted.single.mcfunction"
+            }
+          },
+          "match": "[^\\\\']",
+          "name": "meta.literals_string-single"
+        }
+      ]
+    },
+    "say": {
+      "patterns": [
+        {
+          "begin": "^(\\s*)(say)",
+          "beginCaptures": {
+            "1": {
+              "name": "whitespace.mcfunction"
+            },
+            "2": {
+              "name": "keyword.control.flow.mcfunction"
+            }
+          },
+          "end": "\\n",
+          "name": "meta.say.mcfunction",
+          "patterns": [
+            {
+              "captures": {
+                "0": {
+                  "name": "constant.character.escape.mcfunction"
+                }
+              },
+              "match": "\\\\\\s*\\n",
+              "meta": "meta.say.backslash.mcfunction"
+            },
+            {
+              "include": "#literals_string-double"
+            },
+            {
+              "include": "#literals_string-single"
+            }
+          ]
+        },
+        {
+          "begin": "(run)(\\s+)(say)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.mcfunction"
+            },
+            "2": {
+              "name": "whitespace.mcfunction"
+            },
+            "3": {
+              "name": "keyword.control.flow.mcfunction"
+            }
+          },
+          "end": "\\n",
+          "name": "meta.say.mcfunction",
+          "patterns": [
+            {
+              "captures": {
+                "0": {
+                  "name": "constant.character.escape.mcfunction"
+                }
+              },
+              "match": "\\\\\\s*\\n",
+              "meta": "meta.say.backslash.mcfunction"
+            },
+            {
+              "include": "#literals_string-double"
+            },
+            {
+              "include": "#literals_string-single"
+            }
+          ]
+        }
+      ]
+    },
+    "names": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "whitespace.mcfunction"
+            },
+            "2": {
+              "name": "keyword.control.flow.mcfunction"
+            }
+          },
+          "match": "^(\\s*)([a-z_]+)(?=\\s)",
+          "name": "meta.names"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "whitespace.mcfunction"
+            },
+            "2": {
+              "name": "markup.italic.mcfunction"
+            },
+            "3": {
+              "name": "whitespace.mcfunction"
+            },
+            "4": {
+              "name": "keyword.control.flow.mcfunction"
+            }
+          },
+          "match": "^(\\s*)(\\$)( ?)([a-z_]*)",
+          "name": "meta.names"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "entity.name.mcfunction"
+            },
+            "2": {
+              "name": "whitespace.mcfunction"
+            },
+            "3": {
+              "name": "keyword.control.flow.mcfunction"
+            }
+          },
+          "match": "(run)(\\s+)([a-z_]+)",
+          "name": "meta.names"
+        },
+        {
+          "include": "#resource-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "entity.name.mcfunction"
+            }
+          },
+          "match": "[A-Za-z]+(?=\\W)",
+          "name": "meta.names"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "string.unquoted.mcfunction"
+            }
+          },
+          "match": "[A-Za-z_][A-Za-z0-9_.#%$]*",
+          "name": "meta.names"
+        },
+        {
+          "include": "#macro-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "([#%$]|((?<=\\s)\\.))[A-Za-z0-9_.#%$\\-]+",
+          "name": "meta.names"
+        }
+      ]
+    },
+    "macro-name": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.template-expression.begin.mcfunction"
+            },
+            "2": {
+              "name": "variable.other.mcfunction"
+            },
+            "3": {
+              "name": "punctuation.definition.template-expression.end.mcfunction"
+            }
+          },
+          "match": "(\\$\\()([A-Za-z0-9_]*)(\\))",
+          "name": "meta.macro-name"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "constant.numeric.mcfunction"
+            }
+          },
+          "match": "[~^]",
+          "name": "meta.operators"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "keyword.operator.mcfunction"
+            }
+          },
+          "match": "[\\-%?!+*<>\\\\/|&=.:,;]",
+          "name": "meta.operators"
+        }
+      ]
+    },
+    "property": {
+      "patterns": [
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\{",
+          "captures": {
+            "0": {
+              "name": "punctuation.mcfunction"
+            }
+          },
+          "end": "\\}",
+          "name": "meta.property.curly",
+          "patterns": [
+            {
+              "include": "#resource-name"
+            },
+            {
+              "include": "#literals"
+            },
+            {
+              "include": "#property_key"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#property_value"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\[",
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "end": "\\]",
+          "name": "meta.property.square",
+          "patterns": [
+            {
+              "include": "#resource-name"
+            },
+            {
+              "include": "#literals"
+            },
+            {
+              "include": "#property_key"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#property_value"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\(",
+          "captures": {
+            "0": {
+              "name": "punctuation.mcfunction"
+            }
+          },
+          "end": "\\)",
+          "name": "meta.property.paren",
+          "patterns": [
+            {
+              "include": "#resource-name"
+            },
+            {
+              "include": "#literals"
+            },
+            {
+              "include": "#property_key"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#property_value"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "property_key": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "#?[a-z_][a-z_\\.\\-]*\\:[a-z0-9_\\.\\-/]+(?=\\s*\\=:)",
+          "name": "meta.property_key"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "#?[a-z_][a-z0-9_\\.\\-/]+",
+          "name": "meta.property_key"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "variable.other.mcfunction"
+            }
+          },
+          "match": "[A-Za-z_]+[A-Za-z_\\-\\+]*",
+          "name": "meta.property_key"
+        }
+      ]
+    },
+    "property_value": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "string.unquoted.mcfunction"
+            }
+          },
+          "match": "#?[a-z_][a-z_\\.\\-]*\\:[a-z0-9_\\.\\-/]+",
+          "name": "meta.property_value"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "string.unquoted.mcfunction"
+            }
+          },
+          "match": "#?[a-z_][a-z0-9_\\.\\-/]+",
+          "name": "meta.property_value"
+        }
+      ]
+    },
+    "resource-name": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "entity.name.function.mcfunction"
+            }
+          },
+          "match": "#?[a-z_][a-z0-9_.-]*:[a-z0-9_./-]+",
+          "name": "meta.resource-name"
+        },
+        {
+          "captures": {
+            "0": {
+              "name": "entity.name.function.mcfunction"
+            }
+          },
+          "match": "#?[a-z0-9_\\.\\-]+\\/[a-z0-9_\\.\\-\\/]+",
+          "name": "meta.resource-name"
+        }
+      ]
+    },
+    "selectors": {
+      "patterns": [
+        {
+          "captures": {
+            "0": {
+              "name": "support.class.mcfunction"
+            }
+          },
+          "match": "@[a-z]+",
+          "name": "meta.selectors"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR
Adds support for custom textmate grammars. Custom languages can be loaded at runtime by passing a grammar object to the `lang` prop, or preloaded at build time by passing grammar objects to the `customLanguages` option.

### What changed?

- Update hook and component to handle custom languages at runtime and/or build time
- Improved and adapted language resolution function
- Updated documentation and demos to showcase custom language usage

### How to test
- Verify syntax highlighting works with both bundled and custom languages
- Confirm proper language resolution and fallback behavior
- Run PNPM test and ensure all tests pass


fixes #25