### PR TITLE
fix: rerender when theme changes

### DIFF
--- a/.changeset/slow-keys-sip.md
+++ b/.changeset/slow-keys-sip.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+fix: rerender when theme changes

--- a/package/src/useShiki.ts
+++ b/package/src/useShiki.ts
@@ -123,7 +123,7 @@ export const useShikiHighlighter = (
       isMounted = false;
       clearTimeout(timeoutControl.current.timeoutId);
     };
-  }, [code, lang]);
+  }, [code, lang, theme]);
 
   return highlightedCode;
 };


### PR DESCRIPTION
Make sure Shiki Highlighter rerenders the code block when the theme updates.
