### PR TITLE
chore: refactor types, add github changesets integration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "changesets-changelog-clean",
+    { "repo": "avgvstvs96/react-shiki" }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/few-walls-smoke.md
+++ b/.changeset/few-walls-smoke.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Refactor types and add changesets github integration with `changesets-changelog-clean`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.28.1",
+    "changesets-changelog-clean": "^1.3.0",
     "typescript": "^5.7.3"
   },
   "packageManager": "pnpm@10.4.0",

--- a/package/src/component.tsx
+++ b/package/src/component.tsx
@@ -3,83 +3,9 @@ import './styles.css';
 import React from 'react';
 import { clsx } from 'clsx';
 import { useShikiHighlighter } from './hook';
-import type {
-  Language,
-  Theme,
-  HighlighterOptions,
-  Themes,
-} from './types';
+import type { ShikiHighlighterProps, HighlighterOptions } from './types';
 import { resolveLanguage } from './utils';
 
-/**
- * Props for the ShikiHighlighter component
- */
-export interface ShikiHighlighterProps extends HighlighterOptions {
-  /**
-   * The programming language for syntax highlighting
-   * Supports custom textmate grammar objects in addition to Shiki's bundled languages
-   * @see https://shiki.style/languages
-   */
-  language: Language;
-
-  /**
-   * The code to be highlighted
-   */
-  children: string;
-
-  /**
-   * The color theme or themes for syntax highlighting
-   * Supports single, dual, or multiple themes
-   * Supports custom textmate theme objects in addition to Shiki's bundled themes
-   *
-   * @example
-   * theme='github-dark' // single theme
-   * theme={{ light: 'github-light', dark: 'github-dark' }} // multi-theme
-   *
-   * @see https://shiki.style/themes
-   */
-  theme: Theme | Themes;
-
-  /**
-   * Controls the application of default styles to the generated code blocks
-   *
-   * Default styles include padding, overflow handling, border radius, language label styling, and font settings
-   * @default true
-   */
-  addDefaultStyles?: boolean;
-
-  /**
-   * Add custom inline styles to the generated code block
-   */
-  style?: React.CSSProperties;
-
-  /**
-   * Add custom inline styles to the language label
-   */
-  langStyle?: React.CSSProperties;
-
-  /**
-   * Add custom CSS class names to the generated code block
-   */
-  className?: string;
-
-  /**
-   * Add custom CSS class names to the language label
-   */
-  langClassName?: string;
-
-  /**
-   * Whether to show the language label
-   * @default true
-   */
-  showLanguage?: boolean;
-
-  /**
-   * The HTML element that wraps the generated code block.
-   * @default 'pre'
-   */
-  as?: React.ElementType;
-}
 /**
  * ShikiHighlighter is a React component that provides syntax highlighting for code snippets.
  * It uses Shiki to render beautiful, theme-based syntax highlighting with optimized performance.

--- a/package/src/component.tsx
+++ b/package/src/component.tsx
@@ -3,8 +3,84 @@ import './styles.css';
 import React from 'react';
 import { clsx } from 'clsx';
 import { useShikiHighlighter } from './hook';
-import type { ShikiHighlighterProps, HighlighterOptions } from './types';
 import { resolveLanguage } from './utils';
+
+import type {
+  HighlighterOptions,
+  Language,
+  Theme,
+  Themes,
+} from './types';
+
+/**
+ * Props for the ShikiHighlighter component
+ */
+export interface ShikiHighlighterProps extends HighlighterOptions {
+  /**
+   * The programming language for syntax highlighting
+   * Supports custom textmate grammar objects in addition to Shiki's bundled languages
+   * @see https://shiki.style/languages
+   */
+  language: Language;
+
+  /**
+   * The code to be highlighted
+   */
+  children: string;
+
+  /**
+   * The color theme or themes for syntax highlighting
+   * Supports single, dual, or multiple themes
+   * Supports custom textmate theme objects in addition to Shiki's bundled themes
+   *
+   * @example
+   * theme='github-dark' // single theme
+   * theme={{ light: 'github-light', dark: 'github-dark' }} // multi-theme
+   *
+   * @see https://shiki.style/themes
+   */
+  theme: Theme | Themes;
+
+  /**
+   * Controls the application of default styles to the generated code blocks
+   *
+   * Default styles include padding, overflow handling, border radius, language label styling, and font settings
+   * @default true
+   */
+  addDefaultStyles?: boolean;
+
+  /**
+   * Add custom inline styles to the generated code block
+   */
+  style?: React.CSSProperties;
+
+  /**
+   * Add custom inline styles to the language label
+   */
+  langStyle?: React.CSSProperties;
+
+  /**
+   * Add custom CSS class names to the generated code block
+   */
+  className?: string;
+
+  /**
+   * Add custom CSS class names to the language label
+   */
+  langClassName?: string;
+
+  /**
+   * Whether to show the language label
+   * @default true
+   */
+  showLanguage?: boolean;
+
+  /**
+   * The HTML element that wraps the generated code block.
+   * @default 'pre'
+   */
+  as?: React.ElementType;
+}
 
 /**
  * ShikiHighlighter is a React component that provides syntax highlighting for code snippets.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,16 +1,13 @@
-export { ShikiHighlighter as default } from './component';
 export { useShikiHighlighter } from './hook';
-export type { ShikiHighlighterProps } from './component';
+export { ShikiHighlighter as default } from './component';
 
-export {
-  isInlineCode,
-  rehypeInlineCodeProperty,
-  type Element,
-} from './utils';
+export { isInlineCode, rehypeInlineCodeProperty } from './utils';
 
 export type {
   Language,
   Theme,
   Themes,
+  Element,
   HighlighterOptions,
+  ShikiHighlighterProps,
 } from './types';

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,7 +1,10 @@
 export { useShikiHighlighter } from './hook';
-export { ShikiHighlighter as default } from './component';
-
 export { isInlineCode, rehypeInlineCodeProperty } from './utils';
+
+export {
+  ShikiHighlighter as default,
+  type ShikiHighlighterProps,
+} from './component';
 
 export type {
   Language,
@@ -9,5 +12,4 @@ export type {
   Themes,
   Element,
   HighlighterOptions,
-  ShikiHighlighterProps,
 } from './types';

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,5 +1,6 @@
 export { ShikiHighlighter as default } from './component';
 export { useShikiHighlighter } from './hook';
+export type { ShikiHighlighterProps } from './component';
 
 export {
   isInlineCode,

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -48,10 +48,9 @@ type Theme = ThemeRegistrationAny | StringLiteralUnion<BundledTheme>;
  *
  * @see https://shiki.style/guide/dual-themes
  */
-type Themes = Record<
-  string,
-  ThemeRegistrationAny | StringLiteralUnion<BundledTheme>
->;
+type Themes = {
+  [key: string]: ThemeRegistrationAny | StringLiteralUnion<BundledTheme>;
+};
 
 /**
  * Configuration options specific to react-shiki

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -22,10 +22,8 @@ type Element = HastElement;
  * @see https://shiki.style/languages
  */
 type Language =
-  | BundledLanguage
   | LanguageRegistration
-  | SpecialLanguage
-  | (string & {})
+  | StringLiteralUnion<BundledLanguage | SpecialLanguage>
   | undefined;
 
 /**
@@ -57,7 +55,7 @@ type Themes = {
 /**
  * Configuration options specific to react-shiki
  */
-type ReactShikiOptions = {
+interface ReactShikiOptions {
   /**
    * Minimum time (in milliseconds) between highlight operations.
    * @default undefined (no throttling)
@@ -68,22 +66,23 @@ type ReactShikiOptions = {
    * Custom textmate grammars to be preloaded for highlighting.
    */
   customLanguages?: LanguageRegistration | LanguageRegistration[];
-};
+}
 
 /**
  * Configuration options for the syntax highlighter
  */
-type HighlighterOptions = ReactShikiOptions &
-  Pick<
-    CodeOptionsMultipleThemes<BundledTheme>,
-    'defaultColor' | 'cssVariablePrefix'
-  > &
-  Pick<CodeToHastOptionsCommon, 'transformers'>;
+interface HighlighterOptions
+  extends ReactShikiOptions,
+    Pick<
+      CodeOptionsMultipleThemes<BundledTheme>,
+      'defaultColor' | 'cssVariablePrefix'
+    >,
+    Pick<CodeToHastOptionsCommon, 'transformers'> {}
 
 /**
  * Props for the ShikiHighlighter component
  */
-export interface ShikiHighlighterProps extends HighlighterOptions {
+interface ShikiHighlighterProps extends HighlighterOptions {
   /**
    * The programming language for syntax highlighting
    * Supports custom textmate grammar objects in addition to Shiki's bundled languages
@@ -150,11 +149,10 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
   as?: React.ElementType;
 }
 
-
 /**
  * State for the throttling logic
  */
-type TimeoutState = {
+interface TimeoutState {
   /**
    * Id of the timeout that is currently scheduled
    */
@@ -163,6 +161,14 @@ type TimeoutState = {
    * Next time when the timeout can be scheduled
    */
   nextAllowedTime: number;
-};
+}
 
-export type { Language, Theme, Themes, HighlighterOptions, TimeoutState, Element };
+export type {
+  Language,
+  Theme,
+  Themes,
+  Element,
+  TimeoutState,
+  HighlighterOptions,
+  ShikiHighlighterProps,
+};

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -48,9 +48,10 @@ type Theme = ThemeRegistrationAny | StringLiteralUnion<BundledTheme>;
  *
  * @see https://shiki.style/guide/dual-themes
  */
-type Themes = {
-  [key: string]: ThemeRegistrationAny | StringLiteralUnion<BundledTheme>;
-};
+type Themes = Record<
+  string,
+  ThemeRegistrationAny | StringLiteralUnion<BundledTheme>
+>;
 
 /**
  * Configuration options specific to react-shiki

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -80,75 +80,6 @@ interface HighlighterOptions
     >,
     Pick<CodeToHastOptionsCommon, 'transformers'> {}
 
-/**
- * Props for the ShikiHighlighter component
- */
-interface ShikiHighlighterProps extends HighlighterOptions {
-  /**
-   * The programming language for syntax highlighting
-   * Supports custom textmate grammar objects in addition to Shiki's bundled languages
-   * @see https://shiki.style/languages
-   */
-  language: Language;
-
-  /**
-   * The code to be highlighted
-   */
-  children: string;
-
-  /**
-   * The color theme or themes for syntax highlighting
-   * Supports single, dual, or multiple themes
-   * Supports custom textmate theme objects in addition to Shiki's bundled themes
-   *
-   * @example
-   * theme='github-dark' // single theme
-   * theme={{ light: 'github-light', dark: 'github-dark' }} // multi-theme
-   *
-   * @see https://shiki.style/themes
-   */
-  theme: Theme | Themes;
-
-  /**
-   * Controls the application of default styles to the generated code blocks
-   *
-   * Default styles include padding, overflow handling, border radius, language label styling, and font settings
-   * @default true
-   */
-  addDefaultStyles?: boolean;
-
-  /**
-   * Add custom inline styles to the generated code block
-   */
-  style?: React.CSSProperties;
-
-  /**
-   * Add custom inline styles to the language label
-   */
-  langStyle?: React.CSSProperties;
-
-  /**
-   * Add custom CSS class names to the generated code block
-   */
-  className?: string;
-
-  /**
-   * Add custom CSS class names to the language label
-   */
-  langClassName?: string;
-
-  /**
-   * Whether to show the language label
-   * @default true
-   */
-  showLanguage?: boolean;
-
-  /**
-   * The HTML element that wraps the generated code block.
-   * @default 'pre'
-   */
-  as?: React.ElementType;
-}
 
 /**
  * State for the throttling logic
@@ -171,5 +102,4 @@ export type {
   Element,
   TimeoutState,
   HighlighterOptions,
-  ShikiHighlighterProps,
 };

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -2,7 +2,6 @@ import type {
   BundledLanguage,
   SpecialLanguage,
   BundledTheme,
-  ShikiTransformer,
   CodeOptionsMultipleThemes,
   CodeToHastOptionsCommon,
   ThemeRegistrationAny,
@@ -10,6 +9,13 @@ import type {
 } from 'shiki';
 
 import type { LanguageRegistration } from './extended-types';
+
+import type { Element as HastElement } from 'hast';
+
+/**
+ * HTML Element, use to type `node` from react-markdown
+ */
+type Element = HastElement;
 
 /**
  * A Shiki BundledLanguage or a custom textmate grammar object
@@ -75,6 +81,77 @@ type HighlighterOptions = ReactShikiOptions &
   Pick<CodeToHastOptionsCommon, 'transformers'>;
 
 /**
+ * Props for the ShikiHighlighter component
+ */
+export interface ShikiHighlighterProps extends HighlighterOptions {
+  /**
+   * The programming language for syntax highlighting
+   * Supports custom textmate grammar objects in addition to Shiki's bundled languages
+   * @see https://shiki.style/languages
+   */
+  language: Language;
+
+  /**
+   * The code to be highlighted
+   */
+  children: string;
+
+  /**
+   * The color theme or themes for syntax highlighting
+   * Supports single, dual, or multiple themes
+   * Supports custom textmate theme objects in addition to Shiki's bundled themes
+   *
+   * @example
+   * theme='github-dark' // single theme
+   * theme={{ light: 'github-light', dark: 'github-dark' }} // multi-theme
+   *
+   * @see https://shiki.style/themes
+   */
+  theme: Theme | Themes;
+
+  /**
+   * Controls the application of default styles to the generated code blocks
+   *
+   * Default styles include padding, overflow handling, border radius, language label styling, and font settings
+   * @default true
+   */
+  addDefaultStyles?: boolean;
+
+  /**
+   * Add custom inline styles to the generated code block
+   */
+  style?: React.CSSProperties;
+
+  /**
+   * Add custom inline styles to the language label
+   */
+  langStyle?: React.CSSProperties;
+
+  /**
+   * Add custom CSS class names to the generated code block
+   */
+  className?: string;
+
+  /**
+   * Add custom CSS class names to the language label
+   */
+  langClassName?: string;
+
+  /**
+   * Whether to show the language label
+   * @default true
+   */
+  showLanguage?: boolean;
+
+  /**
+   * The HTML element that wraps the generated code block.
+   * @default 'pre'
+   */
+  as?: React.ElementType;
+}
+
+
+/**
  * State for the throttling logic
  */
 type TimeoutState = {
@@ -88,4 +165,4 @@ type TimeoutState = {
   nextAllowedTime: number;
 };
 
-export type { Language, Theme, Themes, HighlighterOptions, TimeoutState };
+export type { Language, Theme, Themes, HighlighterOptions, TimeoutState, Element };

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -1,14 +1,15 @@
 import { visit } from 'unist-util-visit';
 import { bundledLanguages, isSpecialLang } from 'shiki';
-import type { ShikiTransformer, ThemeRegistrationAny } from 'shiki';
-import type { Element } from 'hast';
-import type { Language, Theme, Themes, TimeoutState } from './types';
-import type { LanguageRegistration } from './extended-types';
 
-/**
- * Type for the HAST node, use to type `node` from react-markdown
- */
-export type { Element };
+import type { ShikiTransformer, ThemeRegistrationAny } from 'shiki';
+import type { LanguageRegistration } from './extended-types';
+import type {
+  Language,
+  Theme,
+  Themes,
+  TimeoutState,
+  Element,
+} from './types';
 
 /**
  * Rehype plugin to add an 'inline' property to <code> elements

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.28.1
         version: 2.28.1
+      changesets-changelog-clean:
+        specifier: ^1.3.0
+        version: 1.3.0
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -276,6 +279,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@4.0.8':
     resolution: {integrity: sha512-MM4mq2+DQU1ZT7nqxnpveDMTkMBLnwNX44cX7NSxlXmr7f8hO6/S2MXNiXG54uf/0nYnefv0cfy4Czf/ZL/EKQ==}
@@ -1154,6 +1160,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  changesets-changelog-clean@1.3.0:
+    resolution: {integrity: sha512-3bGEYg+SuzS4TizAVwGxkiV+c/IMQI7+JPnrEApbvGeb5//c2cfcLG9pteNqpySVY6BNkpCFMM4dpZucnCPxtQ==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1237,6 +1246,9 @@ packages:
   data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
     engines: {node: '>=14'}
+
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -2084,6 +2096,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
@@ -2558,6 +2579,9 @@ packages:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -2730,6 +2754,9 @@ packages:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
     engines: {node: '>=14'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -2748,6 +2775,9 @@ packages:
   whatwg-url@12.0.1:
     resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
     engines: {node: '>=14'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -3049,6 +3079,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.1
+
+  '@changesets/get-github-info@0.6.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.8':
     dependencies:
@@ -3850,6 +3887,13 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  changesets-changelog-clean@1.3.0:
+    dependencies:
+      '@changesets/get-github-info': 0.6.0
+      '@changesets/types': 6.1.0
+    transitivePeerDependencies:
+      - encoding
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -3915,6 +3959,8 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
+
+  dataloader@1.4.0: {}
 
   debug@4.4.0:
     dependencies:
@@ -5077,6 +5123,10 @@ snapshots:
 
   nanoid@3.3.8: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-releases@2.0.19: {}
 
   nwsapi@2.2.16: {}
@@ -5598,6 +5648,8 @@ snapshots:
       universalify: 0.2.0
       url-parse: 1.5.10
 
+  tr46@0.0.3: {}
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -5784,6 +5836,8 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@4.0.2: {}
 
   webidl-conversions@7.0.0: {}
@@ -5798,6 +5852,11 @@ snapshots:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   whatwg-url@7.1.0:
     dependencies:


### PR DESCRIPTION
### TL;DR
Export component props type, update `Language` type, refactor `types.ts`, add changesets github integration

### Changes
- Added `changesets-changelog-clean` for better GitHub integration in changelogs
- Exported `ShikiHighlighterProps` type for better component API documentation
- Refined the `Language` type to use `StringLiteralUnion` for better type safety
- Converted type aliases to interfaces where appropriate
- Reorganized type imports/exports for more consistent code structure
