### PR TITLE
perf: Migrate to `codeToHast`, convert hast directly to react elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "playground:dev": "pnpm --filter playground dev",
     "playground:build": "pnpm --filter playground build",
     "test": "pnpm --filter react-shiki test",
+    "bench": "pnpm --filter react-shiki bench",
     "lint": "pnpm --filter react-shiki lint",
     "lint:fix": "pnpm --filter react-shiki lint:fix",
     "check": "pnpm --filter react-shiki check",

--- a/package/package.json
+++ b/package/package.json
@@ -52,7 +52,6 @@
     "@types/jest": "^29.5.14",
     "clsx": "^2.1.1",
     "hast-util-to-jsx-runtime": "^2.3.6",
-    "html-react-parser": "^5.2.3",
     "shiki": "^3.2.1",
     "unist-util-visit": "^5.0.0"
   },
@@ -64,6 +63,8 @@
     "@types/react": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^26.0.0",
+    "benny": "^3.7.1",
+    "html-react-parser": "^5.2.3",
     "tsup": "^8.4.0",
     "vitest": "^3.1.1"
   }

--- a/package/package.json
+++ b/package/package.json
@@ -52,7 +52,9 @@
     "@types/jest": "^29.5.14",
     "clsx": "^2.1.1",
     "html-react-parser": "^5.2.3",
+    "rehype-react": "^8.0.0",
     "shiki": "^3.2.1",
+    "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -39,6 +39,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "test": "vitest",
+    "bench": "vitest bench",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format --write .",

--- a/package/package.json
+++ b/package/package.json
@@ -51,10 +51,9 @@
   "dependencies": {
     "@types/jest": "^29.5.14",
     "clsx": "^2.1.1",
+    "hast-util-to-jsx-runtime": "^2.3.6",
     "html-react-parser": "^5.2.3",
-    "rehype-react": "^8.0.0",
     "shiki": "^3.2.1",
-    "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {

--- a/package/src/__tests__/performance.bench.ts
+++ b/package/src/__tests__/performance.bench.ts
@@ -1,0 +1,245 @@
+// attribution: ai written test
+import { describe, bench, beforeAll, afterAll } from 'vitest';
+
+import {
+  getSingletonHighlighter,
+  type CodeToHastOptions,
+  type Highlighter,
+} from 'shiki';
+import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
+import htmlReactParser from 'html-react-parser';
+
+import type {
+  Language,
+  Theme,
+  Themes,
+  HighlighterOptions,
+} from '../types';
+
+import {
+  removeTabIndexFromPre,
+  resolveLanguage,
+  resolveTheme,
+} from '../utils';
+
+// --- Test Data ---
+
+const sampleCodeJS = `
+function hello(name) {
+  console.log('Hello, ' + name + '!');
+  const arr = [1, 2, 3, 4, 5];
+  const sum = arr.reduce((acc, val) => acc + val, 0);
+  // This is a simple comment
+  return { message: \`The sum is \${sum}\`, timestamp: new Date() };
+}
+const result = hello('Developer');
+console.log(result);
+`.trim();
+
+const sampleCodeTSX = `
+import React, { useState, useEffect } from 'react';
+
+interface MyComponentProps {
+  initialTitle: string;
+  items: string[];
+}
+
+export const MyComponent: React.FC<MyComponentProps> = ({ initialTitle, items }) => {
+  const [title, setTitle] = useState<string>(initialTitle);
+  const [count, setCount] = useState<number>(0);
+
+  useEffect(() => {
+    document.title = \`\${title} - Count: \${count}\`;
+  }, [title, count]);
+
+  const handleIncrement = () => {
+    setCount(prev => prev + 1);
+  };
+
+  return (
+    <div className="my-tsx-component" data-testid="component-root">
+      <h1>{title}</h1>
+      <p>Current Count: <strong>{count}</strong></p>
+      <button type="button" onClick={handleIncrement}>Increment</button>
+      <ul>
+        {items.map((item, index) => <li key={index}>{item}</li>)}
+      </ul>
+      {/* Example comment */}
+      <style jsx>{\`
+        .my-tsx-component {
+          font-family: sans-serif;
+          border: 2px solid teal;
+          padding: 15px;
+          margin-bottom: 10px;
+        }
+        h1 {
+          color: purple;
+        }
+        button {
+          margin-top: 10px;
+          cursor: pointer;
+        }
+      \`}</style>
+    </div>
+  );
+};
+`.trim();
+
+// --- Test Configurations ---
+
+const configs = [
+  {
+    name: 'JS Single Theme',
+    code: sampleCodeJS,
+    lang: 'javascript',
+    theme: 'github-dark',
+  },
+  {
+    name: 'TSX Single Theme',
+    code: sampleCodeTSX,
+    lang: 'tsx',
+    theme: 'github-dark',
+  },
+  {
+    name: 'JS Multi Theme',
+    code: sampleCodeJS,
+    lang: 'javascript',
+    theme: { light: 'github-light', dark: 'github-dark' },
+  },
+  {
+    name: 'TSX Multi Theme',
+    code: sampleCodeTSX,
+    lang: 'tsx',
+    theme: { light: 'github-light', dark: 'github-dark' },
+  },
+];
+
+const shikiOptionsBase: Partial<HighlighterOptions> = {
+  transformers: [removeTabIndexFromPre],
+};
+
+// --- Benchmark Functions ---
+
+// Approach A: codeToHast -> toJsxRuntime
+async function runApproachA(
+  highlighter: Highlighter,
+  code: string,
+  lang: Language,
+  theme: Theme | Themes
+) {
+  const { languageId } = resolveLanguage(lang);
+  const { isMultiTheme, singleTheme, multiTheme } = resolveTheme(theme);
+
+  const options: CodeToHastOptions = {
+    ...shikiOptionsBase,
+    lang: languageId,
+    ...(isMultiTheme
+      ? { themes: multiTheme as Themes }
+      : { theme: singleTheme as Theme }),
+  };
+
+  const hast = highlighter.codeToHast(code, options);
+  const reactNodes = toJsxRuntime(hast, { jsx, jsxs, Fragment });
+  return reactNodes;
+}
+
+// Approach B: codeToHtml -> htmlReactParser
+async function runApproachB(
+  highlighter: Highlighter,
+  code: string,
+  lang: Language,
+  theme: Theme | Themes
+) {
+  const { languageId } = resolveLanguage(lang);
+  const { isMultiTheme, singleTheme, multiTheme } = resolveTheme(theme);
+
+  const options: CodeToHastOptions = {
+    ...(shikiOptionsBase as CodeToHastOptions),
+    lang: languageId,
+    ...(isMultiTheme
+      ? { themes: multiTheme as Themes }
+      : { theme: singleTheme as Theme }),
+  };
+
+  const html = highlighter.codeToHtml(code, options);
+  const reactNodes = htmlReactParser(html);
+  return reactNodes;
+}
+
+// --- Vitest Benchmark Suite ---
+
+let highlighterInstance: Highlighter | null = null;
+
+beforeAll(async () => {
+  console.log('Initializing Shiki highlighter for benchmarks...');
+  try {
+    const languagesToLoad = new Set(
+      configs
+        .map((c) => resolveLanguage(c.lang).langsToLoad)
+        .filter(Boolean)
+    );
+    const themesToLoad = new Set(
+      configs
+        .flatMap((c) => resolveTheme(c.theme).themesToLoad)
+        .filter(Boolean)
+    );
+
+    highlighterInstance = await getSingletonHighlighter({
+      langs: Array.from(languagesToLoad) as any[],
+      themes: Array.from(themesToLoad) as Theme[],
+    });
+    console.log('Highlighter initialized successfully.');
+  } catch (error) {
+    console.error('Failed to initialize Shiki highlighter:', error);
+    // Optionally re-throw or handle the error to prevent tests from running without the instance
+    throw new Error(`Shiki initialization failed in beforeAll: ${error}`);
+  }
+}, 30000);
+
+// Cleanup
+afterAll(() => {
+  highlighterInstance?.dispose();
+  highlighterInstance = null;
+  console.log('Benchmark suite finished.');
+});
+
+// Loop through configurations and create describe blocks
+// biome-ignore lint/complexity/noForEach: <explanation>
+configs.forEach((config) => {
+  // Use .concurrent here if benchmarks are independent and you want potential speedup
+  // Note: Concurrency might slightly affect stability if resource contention is high.
+  describe(`Scenario: ${config.name}`, () => {
+    // Benchmark Approach A for this config
+    bench(
+      'codeToHast -> toJsxRuntime',
+      async () => {
+        if (!highlighterInstance)
+          throw new Error('Highlighter not initialized in bench A'); // Add safeguard anyway
+        await runApproachA(
+          highlighterInstance,
+          config.code,
+          config.lang,
+          config.theme
+        );
+      },
+      { time: 1000, iterations: 10 }
+    );
+
+    // Benchmark Approach B for this config
+    bench(
+      'codeToHtml -> html-react-parser',
+      async () => {
+        if (!highlighterInstance)
+          throw new Error('Highlighter not initialized in bench B'); // Add safeguard anyway
+        await runApproachB(
+          highlighterInstance,
+          config.code,
+          config.lang,
+          config.theme
+        );
+      },
+      { time: 1000, iterations: 10 }
+    );
+  });
+});

--- a/package/src/hook.ts
+++ b/package/src/hook.ts
@@ -6,7 +6,9 @@ import {
   type ReactNode,
 } from 'react';
 
-import parse from 'html-react-parser';
+import { unified } from 'unified';
+import rehypeReact from 'rehype-react';
+import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
 
 import {
   getSingletonHighlighter,
@@ -35,7 +37,7 @@ import {
   resolveTheme,
 } from './utils';
 
-const DEFAULT_THEMES = {
+const DEFAULT_THEMES: Themes = {
   light: 'github-light',
   dark: 'github-dark',
 };
@@ -133,6 +135,16 @@ export const useShikiHighlighter = (
     return { ...commonOptions, ...themeOptions };
   };
 
+  const hastToReact = useMemo(
+    () =>
+      unified().use(rehypeReact, {
+        jsx,
+        jsxs,
+        Fragment,
+      }),
+    []
+  );
+
   useEffect(() => {
     let isMounted = true;
 
@@ -145,10 +157,10 @@ export const useShikiHighlighter = (
 
       const highlighterOptions: CodeToHastOptions = buildShikiOptions();
 
-      const html = highlighter.codeToHtml(code, highlighterOptions);
+      const hast = highlighter.codeToHast(code, highlighterOptions);
 
       if (isMounted) {
-        setHighlightedCode(parse(html));
+        setHighlightedCode(hastToReact.stringify(hast));
       }
     };
 

--- a/package/src/hook.ts
+++ b/package/src/hook.ts
@@ -35,7 +35,6 @@ import {
   resolveLanguage,
   resolveTheme,
 } from './utils';
-import type { Root } from 'hast';
 
 const DEFAULT_THEMES: Themes = {
   light: 'github-light',
@@ -134,14 +133,6 @@ export const useShikiHighlighter = (
 
     return { ...commonOptions, ...themeOptions };
   };
-
-  // const hastToReact = useMemo(
-  //   () => ({
-  //     stringify: (hast: Root) =>
-  //       toJsxRuntime(hast, { jsx, jsxs, Fragment }),
-  //   }),
-  //   []
-  // );
 
   useEffect(() => {
     let isMounted = true;

--- a/package/src/hook.ts
+++ b/package/src/hook.ts
@@ -6,9 +6,8 @@ import {
   type ReactNode,
 } from 'react';
 
-import { unified } from 'unified';
-import rehypeReact from 'rehype-react';
 import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 
 import {
   getSingletonHighlighter,
@@ -36,6 +35,7 @@ import {
   resolveLanguage,
   resolveTheme,
 } from './utils';
+import type { Root } from 'hast';
 
 const DEFAULT_THEMES: Themes = {
   light: 'github-light',
@@ -135,15 +135,13 @@ export const useShikiHighlighter = (
     return { ...commonOptions, ...themeOptions };
   };
 
-  const hastToReact = useMemo(
-    () =>
-      unified().use(rehypeReact, {
-        jsx,
-        jsxs,
-        Fragment,
-      }),
-    []
-  );
+  // const hastToReact = useMemo(
+  //   () => ({
+  //     stringify: (hast: Root) =>
+  //       toJsxRuntime(hast, { jsx, jsxs, Fragment }),
+  //   }),
+  //   []
+  // );
 
   useEffect(() => {
     let isMounted = true;
@@ -160,7 +158,7 @@ export const useShikiHighlighter = (
       const hast = highlighter.codeToHast(code, highlighterOptions);
 
       if (isMounted) {
-        setHighlightedCode(hastToReact.stringify(hast));
+        setHighlightedCode(toJsxRuntime(hast, { jsx, jsxs, Fragment }));
       }
     };
 

--- a/package/vitest.config.ts
+++ b/package/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/__tests__/test-setup.ts',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'src/**/*.bench.{ts,tsx}'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      hast-util-to-jsx-runtime:
+        specifier: ^2.3.6
+        version: 2.3.6
       html-react-parser:
         specifier: ^5.2.3
         version: 5.2.3(@types/react@19.1.0)(react@19.1.0)
@@ -41,9 +44,6 @@ importers:
       shiki:
         specifier: ^3.2.1
         version: 3.2.1
-      unified:
-        specifier: ^11.0.5
-        version: 11.0.5
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1610,6 +1610,9 @@ packages:
   hast-util-to-jsx-runtime@2.3.3:
     resolution: {integrity: sha512-pdpkP8YD4v+qMKn2lnKSiJvZvb3FunDmFYQvVOsoO08+eTNWdaWKPMrC5wwNICtU3dQWHhElj5Sf5jPEnv4qJg==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
@@ -2353,9 +2356,6 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
-
-  rehype-react@8.0.0:
-    resolution: {integrity: sha512-vzo0YxYbB2HE+36+9HWXVdxNoNDubx63r5LBzpxBGVWM8s9mdnMdbmuJBAX6TTyuGdZjZix6qU3GcSuKCIWivw==}
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
@@ -4476,6 +4476,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.6
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.0.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.16
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -5380,14 +5400,6 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
-
-  rehype-react@8.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-to-jsx-runtime: 2.3.3
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   rehype-recma@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1662,9 +1662,6 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
-  hast-util-to-jsx-runtime@2.3.3:
-    resolution: {integrity: sha512-pdpkP8YD4v+qMKn2lnKSiJvZvb3FunDmFYQvVOsoO08+eTNWdaWKPMrC5wwNICtU3dQWHhElj5Sf5jPEnv4qJg==}
-
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -3559,7 +3556,7 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.3
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.0(acorn@8.14.0)
@@ -4627,26 +4624,6 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
-
-  hast-util-to-jsx-runtime@2.3.3:
-    dependencies:
-      '@types/estree': 1.0.6
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      estree-util-is-identifier-name: 3.0.0
-      hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.0.0
-      space-separated-tokens: 2.0.2
-      style-to-object: 1.0.8
-      unist-util-position: 5.0.0
-      vfile-message: 4.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@5.4.17(@types/node@22.14.0)(lightningcss@1.29.2))
+      benny:
+        specifier: ^3.7.1
+        version: 3.7.1
+      html-react-parser:
+        specifier: ^5.2.3
+        version: 5.2.3(@types/react@19.1.0)(react@18.3.1)
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
@@ -124,6 +130,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@arrows/array@1.4.1':
+    resolution: {integrity: sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==}
+
+  '@arrows/composition@1.2.2':
+    resolution: {integrity: sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==}
+
+  '@arrows/dispatch@1.0.3':
+    resolution: {integrity: sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==}
+
+  '@arrows/error@1.0.2':
+    resolution: {integrity: sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==}
+
+  '@arrows/multimethod@1.4.1':
+    resolution: {integrity: sha512-AZnAay0dgPnCJxn3We5uKiB88VL+1ZIF2SjZohLj6vqY2UyvB/sKdDnFP+LZNVsTC5lcnGPmLlRRkAh4sXkXsQ==}
 
   '@asamuzakjp/css-color@3.1.1':
     resolution: {integrity: sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==}
@@ -1078,6 +1099,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1123,6 +1148,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1139,6 +1168,13 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  benchmark@2.1.4:
+    resolution: {integrity: sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==}
+
+  benny@3.7.1:
+    resolution: {integrity: sha512-USzYxODdVfOS7JuQq/L0naxB788dWCiUgUTxvN+WLPt/JfcDURNNj8kN/N+uK6PDvuR67/9/55cVKGPleFQINA==}
+    engines: {node: '>=12'}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -1226,6 +1262,10 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1250,6 +1290,14 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+
+  common-tags@1.8.2:
+    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
+    engines: {node: '>=4.0.0'}
 
   consola@3.4.0:
     resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
@@ -1489,6 +1537,9 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -1523,6 +1574,10 @@ packages:
   form-data@4.0.2:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1834,6 +1889,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json2csv@5.0.7:
+    resolution: {integrity: sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==}
+    engines: {node: '>= 10', npm: '>= 6.13.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -1841,6 +1902,17 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   lightningcss-darwin-arm64@1.29.2:
     resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
@@ -1924,6 +1996,10 @@ packages:
   lodash.castarray@4.4.0:
     resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
 
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
@@ -1938,6 +2014,10 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-update@4.0.0:
+    resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
+    engines: {node: '>=10'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2093,6 +2173,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2154,6 +2238,10 @@ packages:
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   oniguruma-parser@0.5.4:
     resolution: {integrity: sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==}
@@ -2241,6 +2329,9 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2373,6 +2464,10 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2449,6 +2544,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2456,6 +2554,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2638,6 +2740,10 @@ packages:
       typescript:
         optional: true
 
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -2670,6 +2776,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   update-browserslist-db@1.1.2:
     resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
@@ -2844,6 +2954,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -2885,6 +2999,25 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@arrows/array@1.4.1':
+    dependencies:
+      '@arrows/composition': 1.2.2
+
+  '@arrows/composition@1.2.2': {}
+
+  '@arrows/dispatch@1.0.3':
+    dependencies:
+      '@arrows/composition': 1.2.2
+
+  '@arrows/error@1.0.2': {}
+
+  '@arrows/multimethod@1.4.1':
+    dependencies:
+      '@arrows/array': 1.4.1
+      '@arrows/composition': 1.2.2
+      '@arrows/error': 1.0.2
+      fast-deep-equal: 3.1.3
 
   '@asamuzakjp/css-color@3.1.1':
     dependencies:
@@ -3841,6 +3974,10 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -3874,6 +4011,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  astral-regex@2.0.0: {}
+
   astring@1.9.0: {}
 
   asynckit@0.4.0: {}
@@ -3885,6 +4024,23 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  benchmark@2.1.4:
+    dependencies:
+      lodash: 4.17.21
+      platform: 1.3.6
+
+  benny@3.7.1:
+    dependencies:
+      '@arrows/composition': 1.2.2
+      '@arrows/dispatch': 1.0.3
+      '@arrows/multimethod': 1.4.1
+      benchmark: 2.1.4
+      common-tags: 1.8.2
+      fs-extra: 10.1.0
+      json2csv: 5.0.7
+      kleur: 4.1.5
+      log-update: 4.0.0
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3976,6 +4132,10 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   clsx@2.1.1: {}
 
   collapse-white-space@2.1.0: {}
@@ -3993,6 +4153,10 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
+
+  commander@6.2.1: {}
+
+  common-tags@1.8.2: {}
 
   consola@3.4.0: {}
 
@@ -4295,6 +4459,8 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4335,6 +4501,12 @@ snapshots:
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
 
   fs-extra@7.0.1:
     dependencies:
@@ -4748,11 +4920,27 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json2csv@5.0.7:
+    dependencies:
+      commander: 6.2.1
+      jsonparse: 1.3.1
+      lodash.get: 4.4.2
+
   json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonparse@1.3.1: {}
+
+  kleur@4.1.5: {}
 
   lightningcss-darwin-arm64@1.29.2:
     optional: true
@@ -4811,6 +4999,8 @@ snapshots:
 
   lodash.castarray@4.4.0: {}
 
+  lodash.get@4.4.2: {}
+
   lodash.isplainobject@4.0.6: {}
 
   lodash.merge@4.6.2: {}
@@ -4820,6 +5010,13 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.17.21: {}
+
+  log-update@4.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      cli-cursor: 3.1.0
+      slice-ansi: 4.0.0
+      wrap-ansi: 6.2.0
 
   longest-streak@3.1.0: {}
 
@@ -5161,6 +5358,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-fn@2.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@9.0.5:
@@ -5208,6 +5407,10 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   oniguruma-parser@0.5.4: {}
 
@@ -5280,6 +5483,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.6: {}
+
+  platform@1.3.6: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -5435,6 +5640,11 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   reusify@1.0.4: {}
 
   rollup@4.34.8:
@@ -5549,9 +5759,17 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   source-map-js@1.2.1: {}
 
@@ -5730,6 +5948,8 @@ snapshots:
       - tsx
       - yaml
 
+  type-fest@0.21.3: {}
+
   typescript@5.8.2: {}
 
   undici-types@6.21.0: {}
@@ -5772,6 +5992,8 @@ snapshots:
       unist-util-visit-parents: 6.0.1
 
   universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:
@@ -5937,6 +6159,12 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       shiki:
         specifier: ^3.2.1
         version: 3.2.1
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2350,6 +2353,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-react@8.0.0:
+    resolution: {integrity: sha512-vzo0YxYbB2HE+36+9HWXVdxNoNDubx63r5LBzpxBGVWM8s9mdnMdbmuJBAX6TTyuGdZjZix6qU3GcSuKCIWivw==}
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
@@ -5374,6 +5380,14 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-react@8.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-jsx-runtime: 2.3.3
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   rehype-recma@1.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6
-      html-react-parser:
-        specifier: ^5.2.3
-        version: 5.2.3(@types/react@19.1.0)(react@19.1.0)
       react:
         specifier: '>= 16.8.0'
         version: 19.1.0
@@ -71,7 +68,7 @@ importers:
         version: 3.7.1
       html-react-parser:
         specifier: ^5.2.3
-        version: 5.2.3(@types/react@19.1.0)(react@18.3.1)
+        version: 5.2.3(@types/react@19.1.0)(react@19.1.0)
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0


### PR DESCRIPTION
- Removes `html-react-parser` and replaces `codeToHtml` with `codeToHast`
  - Makes highlighting more efficient and more performant by converting hast directly to react using `codeToHast` -> `hast-util-to-jsx-runtime`
  - 5-10% performance improvement over `codeToHtml` -> `html-react-parser` by saving the intermediate step of converting hast to html in Shiki
  - Add benchmark file demonstrating the performance improvement
- Out of scope changes: add `Themes` type to `DEFAULT_THEMES`