### PR TITLE
chore: minor fixes and updates

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
-    "enabled": true
+    "enabled": false
   },
   "linter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "playground:dev": "pnpm --filter playground dev",
     "playground:build": "pnpm --filter playground build",
     "test": "pnpm --filter react-shiki test",
-    "lint": "tsc && biome check .",
-    "lint:fix": "biome check --write .",
-    "format": "biome format --write .",
+    "lint": "pnpm --filter react-shiki lint",
+    "lint:fix": "pnpm --filter react-shiki lint:fix",
+    "check": "pnpm --filter react-shiki check",
+    "format": "pnpm --filter react-shiki format",
     "changeset": "changeset",
     "release": "node scripts/release.mjs"
   },

--- a/package/README.md
+++ b/package/README.md
@@ -152,7 +152,8 @@ ways to replicate this functionality and API.
 
 **Method 1: Using the `isInlineCode` helper:**
 
-`isInlineCode` parses the `node` prop from `react-markdown`, it works by checking for `\n` characters indicating a line break.
+`react-shiki` exports `isInlineCode` which parses the `node` prop from `react-markdown` and identifies inline code by checking for the absence of newline characters:
+
 ```tsx
 import { isInlineCode, ShikiHighlighter } from "react-shiki";
 

--- a/package/README.md
+++ b/package/README.md
@@ -160,6 +160,7 @@ import { isInlineCode, ShikiHighlighter } from "react-shiki";
 const CodeHighlight = ({ className, children, node, ...props }) => {
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
+
   const isInline = node ? isInlineCode(node) : undefined;
 
   return !isInline ? (

--- a/package/README.md
+++ b/package/README.md
@@ -177,9 +177,8 @@ const CodeHighlight = ({ className, children, node, ...props }) => {
 
 `react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that 
 provides the same API as `react-markdown` prior to `9.0.0`. It reintroduces the 
-`inline` prop by checking the parent element of each `<code>` element: `<code>` 
-elements directly nested within <pre> elements are treated as code blocks, and 
-all other `<code>` elements are treated as inline code. 
+`inline` prop which works by checking if `<code>` is nested within a `<pre>` tag, 
+if not, it's considered inline code and the `inline` prop is set to `true`.
 
 It's passed as a `rehypePlugin` to `react-markdown`:
 

--- a/package/README.md
+++ b/package/README.md
@@ -145,10 +145,10 @@ Pass the component to react-markdown as a code component:
 
 ### Handling Inline Code
 
-For your convenience, `react-shiki` exports a couple functions to help determine if code is inline. 
 
-> [!NOTE]
-> `react-markdown` pre `9.0.0` used to expose the `inline` prop on `code` components to help determine if code is inline. This functionality was removed in `9.0.0`, so I built these solutions for my own use and thought it would be helpful to export them.
+`react-markdown` prior to `9.0.0` used to expose the `inline` prop on `code` components to help determine if code is inline. This functionality was removed in `9.0.0`.
+ 
+For your convenience, `react-shiki` exports a couple functions to help determine if code is inline.
 
 **Method 1: Using the `isInlineCode` helper:**
 
@@ -175,9 +175,7 @@ const CodeHighlight = ({ className, children, node, ...props }) => {
 
 **Method 2: Using the `rehypeInlineCodeProperty` plugin:**
 
-`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that adds
-an `inline` property to `react-markdown` to determine if code is inline based on
-the presence of a `<pre>` tag as a parent of `<code>`.
+`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that provides the same functionality and API as the original `inline` prop from `react-markdown` prior to `9.0.0`. It determines if code is inline based on the presence of a `<pre>` tag as a parent of `<code>`.
 
 It's passed as a `rehypePlugin` to `react-markdown`:
 

--- a/package/README.md
+++ b/package/README.md
@@ -152,8 +152,7 @@ For your convenience, `react-shiki` exports a couple functions to help determine
 
 **Method 1: Using the `isInlineCode` helper:**
 
-`isInlineCode` parses the `node` prop from `react-markdown`, it works by checking for `/n` characters indicating a line break.
-
+`isInlineCode` parses the `node` prop from `react-markdown`, it works by checking for `\n` characters indicating a line break.
 ```tsx
 import { isInlineCode, ShikiHighlighter } from "react-shiki";
 

--- a/package/README.md
+++ b/package/README.md
@@ -145,10 +145,10 @@ Pass the component to react-markdown as a code component:
 
 ### Handling Inline Code
 
-
-`react-markdown` prior to `9.0.0` used to expose the `inline` prop on `code` components to help determine if code is inline. This functionality was removed in `9.0.0`.
- 
-For your convenience, `react-shiki` exports a couple functions to help determine if code is inline.
+Prior to `9.0.0`, `react-markdown` exposed the `inline` prop to `code` 
+components which helped to determine if code is inline. This functionality was 
+removed in `9.0.0`. For your convenience, `react-shiki` provides two 
+ways to replicate this functionality and API.
 
 **Method 1: Using the `isInlineCode` helper:**
 
@@ -175,7 +175,11 @@ const CodeHighlight = ({ className, children, node, ...props }) => {
 
 **Method 2: Using the `rehypeInlineCodeProperty` plugin:**
 
-`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that provides the same functionality and API as the original `inline` prop from `react-markdown` prior to `9.0.0`. It determines if code is inline based on the presence of a `<pre>` tag as a parent of `<code>`.
+`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that 
+provides the same API as `react-markdown` prior to `9.0.0`. It reintroduces the 
+`inline` prop by checking the parent element of each `<code>` element: `<code>` 
+elements directly nested within <pre> elements are treated as code blocks, and 
+all other `<code>` elements are treated as inline code. 
 
 It's passed as a `rehypePlugin` to `react-markdown`:
 

--- a/package/README.md
+++ b/package/README.md
@@ -145,11 +145,14 @@ Pass the component to react-markdown as a code component:
 
 ### Handling Inline Code
 
+For your convenience, `react-shiki` exports a couple functions to help determine if code is inline. 
+
+> [!NOTE]
+> `react-markdown` pre `9.0.0` used to expose the `inline` prop on `code` components to help determine if code is inline. This functionality was removed in `9.0.0`, so I built these solutions for my own use and thought it would be helpful to export them.
+
 **Method 1: Using the `isInlineCode` helper:**
 
-There are two ways to check if a code block is inline, both provide the same result:
-`react-shiki` exports `isInlineCode` which parses the `node`
-prop (from `react-markdown`) to determine if the code is inline:
+`isInlineCode` parses the `node` prop from `react-markdown`, it works by checking for `/n` characters indicating a line break.
 
 ```tsx
 import { isInlineCode, ShikiHighlighter } from "react-shiki";
@@ -171,13 +174,13 @@ const CodeHighlight = ({ className, children, node, ...props }) => {
 };
 ```
 
-**Method 2: Using the rehype plugin:**
+**Method 2: Using the `rehypeInlineCodeProperty` plugin:**
 
 `react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that adds
 an `inline` property to `react-markdown` to determine if code is inline based on
 the presence of a `<pre>` tag as a parent of `<code>`.
 
-It's passed as a rehype plugin to `react-markdown`:
+It's passed as a `rehypePlugin` to `react-markdown`:
 
 ```tsx
 import ReactMarkdown from "react-markdown";
@@ -193,7 +196,7 @@ import { rehypeInlineCodeProperty } from "react-shiki";
 </ReactMarkdown>;
 ```
 
-Now `inline` can be accessed as a prop in the `CodeHighlight` component:
+Now `inline` can be accessed as a prop in the `code` component:
 
 ```tsx
 const CodeHighlight = ({

--- a/package/package.json
+++ b/package/package.json
@@ -38,7 +38,11 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "test": "vitest"
+    "test": "vitest",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "biome format --write .",
+    "check": "tsc && biome check ."
   },
   "peerDependencies": {
     "react": ">= 16.8.0",

--- a/package/package.json
+++ b/package/package.json
@@ -41,8 +41,8 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0",
-    "react-dom": ">= 15.0.0"
+    "react": ">= 16.8.0",
+    "react-dom": ">= 16.8.0"
   },
   "dependencies": {
     "@types/jest": "^29.5.14",

--- a/package/src/component.tsx
+++ b/package/src/component.tsx
@@ -1,6 +1,4 @@
 import './styles.css';
-// biome-ignore lint/style/useImportType: React import is needed
-import React from 'react';
 import { clsx } from 'clsx';
 import { useShikiHighlighter } from './hook';
 import { resolveLanguage } from './utils';

--- a/package/src/hook.ts
+++ b/package/src/hook.ts
@@ -10,7 +10,6 @@ import parse from 'html-react-parser';
 
 import {
   getSingletonHighlighter,
-  type Highlighter,
   type CodeToHastOptions,
   type CodeOptionsSingleTheme,
   type CodeOptionsMultipleThemes,

--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -13,5 +13,11 @@ export default defineConfig((options) => {
     minify: !dev,
     injectStyle: true,
     external: [...Object.keys(peerDependencies)],
+
+    // fixes: React is not defined / JSX runtime not automatically injected
+    // https://github.com/egoist/tsup/issues/792#issuecomment-2443773071
+    esbuildOptions(options) {
+      options.jsx = 'automatic';
+    },
   };
 });

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -278,11 +278,14 @@ Pass the component to react-markdown as a code component:
 
 ### Handling Inline Code
 
+Prior to `9.0.0`, `react-markdown` exposed the `inline` prop to `code` 
+components which helped to determine if code is inline. This functionality was 
+removed in `9.0.0`. For your convenience, `react-shiki` provides two 
+ways to replicate this functionality and API.
+
 **Method 1: Using the `isInlineCode` helper:**
 
-There are two ways to check if a code block is inline, both provide the same result:
-`react-shiki` exports `isInlineCode` which parses the `node`
-prop (from `react-markdown`) to determine if the code is inline:
+`react-shiki` exports `isInlineCode` which parses the `node` prop from `react-markdown` and identifies inline code by checking for the absence of newline characters:
 
 <ShikiHighlighter language="tsx" theme="material-theme-ocean">
 {`
@@ -308,9 +311,10 @@ const CodeHighlight = ({ className, children, node, ...props }) => {
 
 **Method 2: Using the rehype plugin:**
 
-`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that adds
-an `inline` property to `react-markdown` to determine if code is inline based on
-the presence of a `<pre>` tag as a parent of `<code>`.
+`react-shiki` also exports `rehypeInlineCodeProperty`, a rehype plugin that 
+provides the same API as `react-markdown` prior to `9.0.0`. It reintroduces the 
+`inline` prop which works by checking if `<code>` is nested within a `<pre>` tag, 
+if not, it's considered inline code and the `inline` prop is set to `true`.
 
 It's passed as a rehype plugin to `react-markdown`:
 

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// biome-ignore lint/style/useNamingConvention: React naming convention
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,13 +31,13 @@ importers:
         version: 2.1.1
       html-react-parser:
         specifier: ^5.2.3
-        version: 5.2.3(@types/react@19.1.0)(react@18.3.1)
+        version: 5.2.3(@types/react@19.1.0)(react@19.1.0)
       react:
-        specifier: '>= 15.0.0'
-        version: 18.3.1
+        specifier: '>= 16.8.0'
+        version: 19.1.0
       react-dom:
-        specifier: '>= 15.0.0'
-        version: 18.3.1(react@18.3.1)
+        specifier: '>= 16.8.0'
+        version: 19.1.0(react@19.1.0)
       shiki:
         specifier: ^3.2.1
         version: 3.2.1
@@ -50,7 +50,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@9.3.4)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@9.3.4)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1936,10 +1936,6 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
@@ -2293,11 +2289,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
-
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -2314,10 +2305,6 @@ packages:
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
-    engines: {node: '>=0.10.0'}
-
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   react@19.1.0:
@@ -2405,9 +2392,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -3677,12 +3661,12 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@9.3.4)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@9.3.4)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.26.9
       '@testing-library/dom': 9.3.4
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.0
       '@types/react-dom': 19.1.1(@types/react@19.1.0)
@@ -4499,11 +4483,11 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
-  html-react-parser@5.2.3(@types/react@19.1.0)(react@18.3.1):
+  html-react-parser@5.2.3(@types/react@19.1.0)(react@19.1.0):
     dependencies:
       domhandler: 5.0.3
       html-dom-parser: 5.0.13
-      react: 18.3.1
+      react: 19.1.0
       react-property: 2.0.2
       style-to-js: 1.1.16
     optionalDependencies:
@@ -4812,10 +4796,6 @@ snapshots:
   lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   loupe@3.1.3: {}
 
@@ -5315,12 +5295,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -5333,10 +5307,6 @@ snapshots:
   react-property@2.0.2: {}
 
   react-refresh@0.14.2: {}
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@19.1.0: {}
 
@@ -5483,10 +5453,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
 


### PR DESCRIPTION
This pull request includes a set of minor fixes and updates to improve the overall code quality and maintainability of the `react-shiki` project. 

- Fix peer dependencies to support only React versions with hooks (`>= 16.8.0`).
- Update `package.json` scripts to correctly handle linting and formatting using `biome`.
- Disable the `organizeImports` feature in `biome.json`.
- Remove unnecessary `biome-ignore` comments.
- Remove unused type declarations.
- Update the lockfile.
- Enhance the README to provide better clarity on handling inline code.
- Fix the need for a React import in components by configuring the build tool to automatically handle JSX.
  - https://github.com/egoist/tsup/issues/792#issuecomment-2443773071

#### File Changes

| File                        | Changes                                                                                                                                                                                                                  |
|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `biome.json`                | Disable `organizeImports` feature.                                                                                                                                                                                      |
| `package.json`              | Update linting and formatting scripts to use `pnpm`. Add new scripts for `check` and `format`.                                                                                                                          |
| `package/README.md`         | Add clarity on handling inline code, including a note about changes in `react-markdown` pre and post version `9.0.0`, and update method descriptions for checking inline code.                                        |
| `package/package.json`      | Update peer dependencies to support only React versions `>= 16.8.0`. Add new scripts for linting, fixing, formatting, and checking.                                                                                      |
| `package/src/component.tsx` | Remove unnecessary `biome-ignore` comment and the now-unneeded React import.                                                                                                                                             |
| `package/src/hook.ts`       | Remove an unused type declaration.                                                                                                                                                                                       |
| `package/tsup.config.ts`    | Add esbuild option `jsx = 'automatic'` to fix the issue of React not being defined without manual import.                                                                                                               |
| `playground/src/main.tsx`   | Remove unnecessary `biome-ignore` comment.                                                                                                                                                                               |



---

*pr summary written with help from copilot*