### PR TITLE
fix: custom language resolution by filetype identifier

### DIFF
--- a/.changeset/bumpy-games-add.md
+++ b/.changeset/bumpy-games-add.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Ensure custom languages can be identified by their filetypes

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -134,9 +134,8 @@ export const resolveLanguage = (
     };
   }
 
-  const lowerLang = lang.toLowerCase();
-
   // Language is string
+  const lowerLang = lang.toLowerCase();
   const matches = (str: string | undefined): boolean =>
     str?.toLowerCase() === lowerLang;
 
@@ -144,9 +143,10 @@ export const resolveLanguage = (
   const customMatch = customLanguages.find(
     (cl) =>
       matches(cl.name) ||
-      cl.aliases?.some(matches) ||
       matches(cl.scopeName) ||
-      matches(cl.scopeName?.split('.').pop())
+      matches(cl.scopeName?.split('.').pop()) ||
+      cl.aliases?.includes(lowerLang) ||
+      cl.fileTypes?.includes(lowerLang)
   );
 
   if (customMatch) {

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -145,8 +145,8 @@ export const resolveLanguage = (
       matches(cl.name) ||
       matches(cl.scopeName) ||
       matches(cl.scopeName?.split('.').pop()) ||
-      cl.aliases?.includes(lowerLang) ||
-      cl.fileTypes?.includes(lowerLang)
+      cl.aliases?.some(matches) ||
+      cl.fileTypes?.some(matches)
   );
 
   if (customMatch) {


### PR DESCRIPTION
### Fixes custom language resolution by file types

When using customLanguages then highlighting code in those langs on the client, the filetypes were not recognized as identifiers for the custom languages so filetypes like `bolt` wasn't properly highlighted as `mcfunction`. This is fixed by checking fileTypes for matches.