### PR TITLE
feat: Add optional line numbers with `showLineNumbers` option

### DIFF
--- a/.changeset/curly-mammals-allow.md
+++ b/.changeset/curly-mammals-allow.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+feat: Add support for line numbers with `showLineNumbers`

--- a/package/README.md
+++ b/package/README.md
@@ -23,6 +23,7 @@ A performant client-side syntax highlighting component and hook for React, built
     - [Custom Languages](#custom-languages)
       - [Preloading Custom Languages](#preloading-custom-languages)
     - [Custom Transformers](#custom-transformers)
+    - [Line Numbers](#line-numbers)
   - [Integration](#integration)
     - [Integration with react-markdown](#integration-with-react-markdown)
     - [Handling Inline Code](#handling-inline-code)
@@ -44,6 +45,7 @@ A performant client-side syntax highlighting component and hook for React, built
 - 🖥️ `ShikiHighlighter` component displays a language label for each code block
   when `showLanguage` is set to `true` (default)
 - 🎨 Customizable styling of generated code blocks and language labels
+- 📏 Optional line numbers with customizable starting number and styling
 
 ## Installation
 
@@ -155,6 +157,8 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `theme`             | `string \| object` | `'github-dark'` | Single or multi-theme configuration, built-in or custom textmate theme object |
 | `delay`             | `number`           | `0`             | Delay between highlights (in milliseconds)                                    |
 | `customLanguages`   | `array`            | `[]`            | Array of custom languages to preload                                          |
+| `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
+| `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
 | `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
 | `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
 | `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |
@@ -221,12 +225,12 @@ Custom themes can be passed as a TextMate theme in JavaScript object. For exampl
 ```tsx
 import tokyoNight from "../styles/tokyo-night.json";
 
-// Using the component
+// Component
 <ShikiHighlighter language="tsx" theme={tokyoNight}>
   {code.trim()}
 </ShikiHighlighter>
 
-// Using the hook
+// Hook
 const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
 ```
 
@@ -237,12 +241,12 @@ Custom languages should be passed as a TextMate grammar in JavaScript object. Fo
 ```tsx
 import mcfunction from "../langs/mcfunction.tmLanguage.json";
 
-// Using the component
+// Component
 <ShikiHighlighter language={mcfunction} theme="github-dark">
   {code.trim()}
 </ShikiHighlighter>
 
-// Using the hook
+// Hook
 const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
 ```
 
@@ -254,7 +258,7 @@ For dynamic highlighting scenarios where language selection happens at runtime:
 import mcfunction from "../langs/mcfunction.tmLanguage.json";
 import bosque from "../langs/bosque.tmLanguage.json";
 
-// With the component
+// Component
 <ShikiHighlighter
   language="typescript"
   theme="github-dark"
@@ -263,7 +267,7 @@ import bosque from "../langs/bosque.tmLanguage.json";
   {code.trim()}
 </ShikiHighlighter>
 
-// With the hook
+// Hook
 const highlightedCode = useShikiHighlighter(code, "typescript", "github-dark", {
   customLanguages: [mcfunction, bosque],
 });
@@ -274,15 +278,80 @@ const highlightedCode = useShikiHighlighter(code, "typescript", "github-dark", {
 ```tsx
 import { customTransformer } from "../utils/shikiTransformers";
 
-// Using the component
+// Component
 <ShikiHighlighter language="tsx" transformers={[customTransformer]}>
   {code.trim()}
 </ShikiHighlighter>
 
-// Using the hook
+// Hook
 const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
   transformers: [customTransformer],
 });
+```
+
+### Line Numbers
+
+Display line numbers alongside your code, these are CSS-based
+and can be customized with CSS variables:
+
+```tsx
+// Component
+<ShikiHighlighter 
+  language="javascript"
+  theme="github-dark"
+  showLineNumbers,
+  startingLineNumber={0} // default is 1
+>
+  {code}
+</ShikiHighlighter>
+
+<ShikiHighlighter 
+  language="python" 
+  theme="github-dark" 
+  showLineNumbers 
+  startingLineNumber={0}
+>
+  {code}
+</ShikiHighlighter>
+
+// Hook (import 'react-shiki/css' for line numbers to work)
+const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
+  showLineNumbers: true,
+  startingLineNumber: 0, 
+});
+```
+
+> [!NOTE]
+> When using the hook with line numbers, import the CSS file for the line numbers to work:
+> ```tsx
+> import 'react-shiki/css';
+> ```
+> Or provide your own CSS counter implementation and styles for `.line-numbers` (line `span`) and `.has-line-numbers` (container `code` element)
+
+Available CSS variables for customization:
+```css
+--line-numbers-foreground: rgba(107, 114, 128, 0.5);
+--line-numbers-width: 2ch;
+--line-numbers-padding-left: 0ch;
+--line-numbers-padding-right: 2ch;
+--line-numbers-font-size: inherit;
+--line-numbers-font-weight: inherit;
+--line-numbers-opacity: 1;
+```
+
+You can customize them in your own CSS or by using the style prop on the component:
+```tsx
+<ShikiHighlighter 
+  language="javascript"
+  theme="github-dark"
+  showLineNumbers
+  style={{
+    '--line-numbers-foreground': '#60a5fa',
+    '--line-numbers-width': '3ch'
+  }}
+>
+  {code}
+</ShikiHighlighter>
 ```
 
 ## Integration

--- a/package/package.json
+++ b/package/package.json
@@ -26,9 +26,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist", "src/lib/styles.css"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -41,7 +39,8 @@
     "./core": {
       "types": "./dist/core.d.ts",
       "default": "./dist/core.js"
-    }
+    },
+    "./css": "./src/lib/styles.css"
   },
   "scripts": {
     "dev": "tsup --watch",

--- a/package/src/__tests__/line-numbers.test.tsx
+++ b/package/src/__tests__/line-numbers.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { ShikiHighlighter } from '../index';
+
+describe('Line Numbers', () => {
+  const code = `function test() {
+  return 'hello';
+}`;
+
+  it('should not show line numbers by default', async () => {
+    const { container } = render(
+      <ShikiHighlighter language="javascript" theme="github-dark">
+        {code}
+      </ShikiHighlighter>
+    );
+
+    // Wait for highlighting to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const container_element = container.querySelector('#shiki-container');
+    expect(container_element).not.toHaveClass('has-line-numbers');
+
+    const lineElements = container.querySelectorAll('.line-numbers');
+    expect(lineElements).toHaveLength(0);
+  });
+
+  it('should show line numbers when enabled', async () => {
+    const { container } = render(
+      <ShikiHighlighter
+        language="javascript"
+        theme="github-dark"
+        showLineNumbers
+      >
+        {code}
+      </ShikiHighlighter>
+    );
+
+    // Wait for highlighting to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toHaveClass('has-line-numbers');
+
+    const lineElements = container.querySelectorAll('.line-numbers');
+    expect(lineElements.length).toBeGreaterThan(0);
+  });
+
+  it('should set custom starting line number', async () => {
+    const { container } = render(
+      <ShikiHighlighter
+        language="javascript"
+        theme="github-dark"
+        showLineNumbers
+        startingLineNumber={42}
+      >
+        {code}
+      </ShikiHighlighter>
+    );
+
+    // Wait for highlighting to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check which elements have the style attribute
+    const elementsWithStyle = container.querySelectorAll(
+      '[style*="--line-start"]'
+    );
+    expect(elementsWithStyle.length).toBeGreaterThan(0);
+    expect(elementsWithStyle[0]?.getAttribute('style')).toContain(
+      '--line-start: 42'
+    );
+  });
+
+  it('should not set line-start CSS variable when starting from 1', async () => {
+    const { container } = render(
+      <ShikiHighlighter
+        language="javascript"
+        theme="github-dark"
+        showLineNumbers
+        startingLineNumber={1}
+      >
+        {code}
+      </ShikiHighlighter>
+    );
+
+    // Wait for highlighting to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const elementsWithStyle = container.querySelectorAll(
+      '[style*="--line-start"]'
+    );
+    expect(elementsWithStyle.length).toBe(0);
+  });
+});

--- a/package/src/__tests__/performance.bench.ts
+++ b/package/src/__tests__/performance.bench.ts
@@ -19,9 +19,9 @@ import { jsx, jsxs, Fragment } from 'react/jsx-runtime';
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import htmlReactParser from 'html-react-parser';
 
-import type { Language, Theme, Themes } from '../types';
+import type { Language, Theme, Themes } from '../lib/types';
 
-import { resolveLanguage, resolveTheme } from '../resolvers';
+import { resolveLanguage, resolveTheme } from '../lib/resolvers';
 // --- Test Data ---
 
 // Small code sample (few lines)

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -73,6 +73,18 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
   showLanguage?: boolean;
 
   /**
+   * Whether to show line numbers
+   * @default false
+   */
+  showLineNumbers?: boolean;
+
+  /**
+   * Starting line number (when showLineNumbers is true)
+   * @default 1
+   */
+  startingLineNumber?: number;
+
+  /**
    * The HTML element that wraps the generated code block.
    * @default 'pre'
    */
@@ -104,6 +116,8 @@ export const createShikiHighlighterComponent = (
     className,
     langClassName,
     showLanguage = true,
+    showLineNumbers = false,
+    startingLineNumber = 1,
     children: code,
     as: Element = 'pre',
     customLanguages,
@@ -115,6 +129,8 @@ export const createShikiHighlighterComponent = (
       customLanguages,
       defaultColor,
       cssVariablePrefix,
+      showLineNumbers,
+      startingLineNumber,
       ...shikiOptions,
     };
 

--- a/package/src/lib/resolvers.ts
+++ b/package/src/lib/resolvers.ts
@@ -71,7 +71,7 @@ export const resolveLanguage = (
     };
   }
 
-  // For any other string, pass it through, 
+  // For any other string, pass it through,
   // fallback is handled in highlighter factories
   return {
     languageId: lang,

--- a/package/src/lib/styles.css
+++ b/package/src/lib/styles.css
@@ -4,19 +4,52 @@
 
 .defaultStyles pre {
   overflow: auto;
-  border-radius: 0.5rem; /* Rounded large */
-  padding-left: 1.5rem; /* Padding x-axis: 6 (1.5rem) */
+  border-radius: 0.5rem;
+  padding-left: 1.5rem;
   padding-right: 1.5rem;
-  padding-top: 1.25rem; /* Padding y-axis: 5 (1.25rem) */
+  padding-top: 1.25rem;
   padding-bottom: 1.25rem;
 }
 
 .languageLabel {
   position: absolute;
-  right: 0.75rem; /* Right: 3 (0.75rem) */
-  top: 0.5rem; /* Top: 2 (0.5rem) */
-  font-family: monospace; /* Font family: monospace */
-  font-size: 0.75rem; /* Text size: xs (0.75rem) */
-  letter-spacing: -0.05em; /* Tracking: tighter (-0.05em) */
-  color: rgba(107, 114, 128, 0.85); /* Muted foreground color with 85% opacity */
+  right: 0.75rem;
+  top: 0.5rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  letter-spacing: -0.05em;
+  color: rgba(107, 114, 128, 0.85);
+}
+
+.line-numbers::before {
+  counter-increment: line-number;
+  content: counter(line-number);
+  display: inline-flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  box-sizing: content-box;
+  min-width: var(--line-numbers-width, 2ch);
+  padding-left: var(--line-numbers-padding-left, 2ch);
+  padding-right: var(--line-numbers-padding-right, 2ch);
+  color: var(--line-numbers-foreground, rgba(107, 114, 128, 0.6));
+  font-size: var(--line-numbers-font-size, inherit);
+  font-weight: var(--line-numbers-font-weight, inherit);
+  line-height: var(--line-numbers-line-height, inherit);
+  font-family: var(--line-numbers-font-family, inherit);
+  opacity: var(--line-numbers-opacity, 1);
+  user-select: none;
+  pointer-events: none;
+}
+
+.has-line-numbers {
+  counter-reset: line-number calc(var(--line-start, 1) - 1);
+  --line-numbers-foreground: rgba(107, 114, 128, 0.5);
+  --line-numbers-width: 2ch;
+  --line-numbers-padding-left: 0ch;
+  --line-numbers-padding-right: 2ch;
+  --line-numbers-font-size: inherit;
+  --line-numbers-font-weight: inherit;
+  --line-numbers-line-height: inherit;
+  --line-numbers-font-family: inherit;
+  --line-numbers-opacity: 1;
 }

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -1,0 +1,28 @@
+import type { ShikiTransformer } from 'shiki/core';
+
+/**
+ * Creates a transformer that enables line numbers display
+ * @param startLine - The starting line number (defaults to 1)
+ */
+export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
+  return {
+    name: 'react-shiki:line-numbers',
+    code(node) {
+      this.addClassToHast(node, 'has-line-numbers');
+      if (startLine !== 1) {
+        const existingStyle = (node.properties?.style as string) || '';
+        const newStyle = existingStyle
+          ? `${existingStyle}; --line-start: ${startLine}`
+          : `--line-start: ${startLine}`;
+        node.properties = {
+          ...node.properties,
+          style: newStyle,
+        };
+      }
+    },
+    line(node) {
+      this.addClassToHast(node, 'line-numbers');
+      return node;
+    },
+  };
+}

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -99,6 +99,18 @@ interface ReactShikiOptions {
    * });
    */
   highlighter?: Highlighter | HighlighterCore;
+
+  /**
+   * Whether to show line numbers
+   * @default false
+   */
+  showLineNumbers?: boolean;
+
+  /**
+   * Starting line number (when showLineNumbers is true)
+   * @default 1
+   */
+  startingLineNumber?: number;
 }
 
 /**

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -512,6 +512,49 @@ const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
 `.trim()}
 </ShikiHighlighter>
 
+## Line Numbers
+
+Display line numbers alongside your code:
+
+<ShikiHighlighter language="tsx" theme="github-dark" showLineNumbers>
+{`
+function fibonacci(n) {
+    if (n <= 1) return n;
+    return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+// Example usage
+const result = fibonacci(10);
+console.log(result); // 55
+`.trim()}
+</ShikiHighlighter>
+
+With custom starting line number:
+
+<ShikiHighlighter language="python" theme="vitesse-dark" showLineNumbers lineNumbersStart={42}>
+{`
+def calculate_area(radius):
+    """Calculate the area of a circle."""
+    import math
+    return math.pi * radius ** 2
+
+# Usage
+area = calculate_area(5)
+print(f"Area: {area}")
+`.trim()}
+</ShikiHighlighter>
+
+Using the hook with line numbers:
+
+<ShikiHighlighter language="tsx" theme="rose-pine">
+{`
+const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
+    showLineNumbers: true,
+    lineNumbersStart: 1,
+});
+`.trim()}
+</ShikiHighlighter>
+
 ## Performance
 
 ### Throttling Real-time Highlighting


### PR DESCRIPTION
Add support for displaying line numbers alongside code blocks with customizable styling and starting line number.


- Add `showLineNumbers` and `startingLineNumber` props to the `ShikiHighlighter` component
- Create a new `lineNumbersTransformer` to handle line number rendering
- Add CSS styling for line numbers with customizable variables
- Update documentation with examples and styling options
- Add tests for line number functionality
- Expose CSS file via package.json exports for standalone usage

```tsx
// Basic usage
<ShikiHighlighter language="javascript" theme="github-dark" showLineNumbers>
  {code}
</ShikiHighlighter>

// Custom starting line number
<ShikiHighlighter 
  language="python" 
  theme="github-dark" 
  showLineNumbers 
  startingLineNumber={42}
>
  {code}
</ShikiHighlighter>

// Custom styling
<ShikiHighlighter 
  language="javascript"
  theme="github-dark"
  showLineNumbers
  style={{
    '--line-numbers-foreground': '#60a5fa',
    '--line-numbers-width': '3ch'
  }}
>
  {code}
</ShikiHighlighter>

// With the hook (import CSS separately)
import 'react-shiki/css';

const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
  showLineNumbers: true,
  startingLineNumber: 42
});
```

---

closes #60