### PR TITLE
ci: setup chanegsets action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm ci:release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check": "pnpm --filter react-shiki check",
     "format": "pnpm --filter react-shiki format",
     "changeset": "changeset",
-    "release": "node scripts/release.mjs"
+    "release": "node scripts/release.mjs",
+    "ci:publish": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
Added GitHub Actions workflow for automated releases using Changesets.

- Created a new GitHub Actions workflow file (`.github/workflows/release.yaml`) that:
    - Runs on pushes to the main branch
    - Sets up Node.js v22 with pnpm
    - Uses the Changesets Action to either create a release PR or publish to npm
- Added a new `ci:publish` script to `package.json` that builds the project and publishes using Changesets

This automation streamlines the release process by using GitHub Actions and Changesets to handle versioning and publishing. It reduces manual steps in the release process and ensures consistent releases with proper version bumps based on the changesets.