### PR TITLE
re-export shiki engines for convenience

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -26,13 +26,8 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "src/lib/styles.css"
-  ],
-  "sideEffects": [
-    "src/lib/styles.css"
-  ],
+  "files": ["dist", "src/lib/styles.css"],
+  "sideEffects": ["src/lib/styles.css"],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/package/src/bundles/full.ts
+++ b/package/src/bundles/full.ts
@@ -1,4 +1,10 @@
-import { getSingletonHighlighter, type Highlighter } from 'shiki';
+import {
+  getSingletonHighlighter,
+  type Highlighter,
+  type Awaitable,
+  type RegexEngine,
+} from 'shiki';
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import type { ShikiLanguageRegistration } from '../lib/extended-types';
 import type { Theme } from '../lib/types';
 
@@ -8,18 +14,21 @@ import type { Theme } from '../lib/types';
  */
 export async function createFullHighlighter(
   langsToLoad: ShikiLanguageRegistration,
-  themesToLoad: Theme[]
+  themesToLoad: Theme[],
+  engine?: Awaitable<RegexEngine>
 ): Promise<Highlighter> {
   try {
     return await getSingletonHighlighter({
       langs: [langsToLoad],
       themes: themesToLoad,
+      engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
     });
   } catch (error) {
     if (error instanceof Error && error.message.includes('Language')) {
       return await getSingletonHighlighter({
         langs: ['plaintext'],
         themes: themesToLoad,
+        engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
       });
     }
     throw error;

--- a/package/src/bundles/web.ts
+++ b/package/src/bundles/web.ts
@@ -1,7 +1,10 @@
 import {
   getSingletonHighlighter,
   type Highlighter,
+  type Awaitable,
+  type RegexEngine,
 } from 'shiki/bundle/web';
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 import type { ShikiLanguageRegistration } from '../lib/extended-types';
 import type { Theme } from '../lib/types';
 
@@ -12,18 +15,21 @@ import type { Theme } from '../lib/types';
  */
 export async function createWebHighlighter(
   langsToLoad: ShikiLanguageRegistration,
-  themesToLoad: Theme[]
+  themesToLoad: Theme[],
+  engine?: Awaitable<RegexEngine>
 ): Promise<Highlighter> {
   try {
     return await getSingletonHighlighter({
       langs: [langsToLoad],
       themes: themesToLoad,
+      engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
     });
   } catch (error) {
     if (error instanceof Error && error.message.includes('Language')) {
       return await getSingletonHighlighter({
         langs: ['plaintext'],
         themes: themesToLoad,
+        engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
       });
     }
     throw error;

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -22,7 +22,10 @@ export type {
 
 export { createHighlighterCore } from 'shiki/core';
 export { createOnigurumaEngine } from 'shiki/engine/oniguruma';
-export { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+export {
+  createJavaScriptRegexEngine,
+  createJavaScriptRawEngine,
+} from 'shiki/engine/javascript';
 
 /**
  * A React hook that provides syntax highlighting using Shiki with a custom highlighter.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -20,6 +20,11 @@ export type {
   HighlighterOptions,
 } from './lib/types';
 
+export {
+  createJavaScriptRegexEngine,
+  createJavaScriptRawEngine,
+} from 'shiki/engine/javascript';
+
 /**
  * A React hook that provides syntax highlighting using Shiki with the full bundle.
  * Includes all languages and themes for maximum compatibility.

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -15,6 +15,8 @@ import type {
   CodeOptionsMultipleThemes,
   Highlighter,
   HighlighterCore,
+  Awaitable,
+  RegexEngine,
 } from 'shiki';
 
 import type { ShikiLanguageRegistration } from './extended-types';
@@ -53,7 +55,8 @@ export const useShikiHighlighter = (
   options: HighlighterOptions = {},
   highlighterFactory: (
     langsToLoad: ShikiLanguageRegistration,
-    themesToLoad: Theme[]
+    themesToLoad: Theme[],
+    engine?: Awaitable<RegexEngine>
   ) => Promise<Highlighter | HighlighterCore>
 ) => {
   const [highlightedCode, setHighlightedCode] = useState<
@@ -127,7 +130,8 @@ export const useShikiHighlighter = (
         ? stableOpts.highlighter
         : await highlighterFactory(
             langsToLoad as ShikiLanguageRegistration,
-            themesToLoad
+            themesToLoad,
+            stableOpts.engine
           );
 
       const loadedLanguages = highlighter.getLoadedLanguages();

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -9,6 +9,8 @@ import type {
   Highlighter,
   HighlighterCore,
   BundledHighlighterOptions,
+  Awaitable,
+  RegexEngine,
 } from 'shiki';
 
 import type { ReactNode } from 'react';
@@ -133,7 +135,10 @@ interface HighlighterOptions
       'defaultColor' | 'cssVariablePrefix'
     >,
     Omit<CodeToHastOptions, 'lang' | 'theme' | 'themes'>,
-    Pick<BundledHighlighterOptions<string, string>, 'langAlias'> {}
+    Pick<
+      BundledHighlighterOptions<string, string>,
+      'langAlias' | 'engine'
+    > {}
 
 /**
  * State for the throttling logic

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -20,6 +20,11 @@ export type {
   HighlighterOptions,
 } from './lib/types';
 
+export {
+  createJavaScriptRegexEngine,
+  createJavaScriptRawEngine,
+} from 'shiki/engine/javascript';
+
 /**
  * A React hook that provides syntax highlighting using Shiki with the web bundle.
  * Includes web-focused languages (HTML, CSS, JS, TS, JSON, Markdown, Astro, JSX, Svelte, Vue etc.)


### PR DESCRIPTION
re-export shiki engines for convenience

format

feat: add support for engine selection in web and full (index) bundles