### PR TITLE
perf: improve throttling with useThrottledDebounce hook

### DIFF
--- a/.changeset/rare-geckos-bathe.md
+++ b/.changeset/rare-geckos-bathe.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Improve throttling with useThrottledDebounce hook

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -140,11 +140,6 @@ interface HighlighterOptions<F extends OutputFormat = 'react'>
       'langAlias' | 'engine'
     > {}
 
-interface TimeoutState {
-  timeoutId: NodeJS.Timeout | undefined;
-  nextAllowedTime: number;
-}
-
 /**
  * Public API signature for the useShikiHighlighter hook.
  * Generic parameter narrows return type based on outputFormat option.
@@ -174,7 +169,6 @@ export type {
   Theme,
   Themes,
   Element,
-  TimeoutState,
   HighlighterOptions,
   OutputFormat,
   OutputFormatMap,


### PR DESCRIPTION
This PR replaces the imperative `throttleHighlighting` function with a reactive `useThrottledDebounce` hook.

## Acknowledgment

Implementation inspired by [streamdown's `useThrottledDebounce` hook](https://github.com/vercel/streamdown/blob/main/packages/streamdown/hooks/use-throttled-debouce.ts), originally authored by [@haydenbleasel](https://github.com/haydenbleasel).

## Changes

**New hybrid throttle+debounce behavior:**
- Immediate update when throttle window has passed
- Debounce for rapid changes within the throttle window
- Proper cleanup to prevent memory leaks

**Code simplification:**
- Removes `TimeoutState` interface
- Moves throttling to a dedicated hook instead of inline effect logic
- Value-based pattern instead of imperative callback

## API

**No breaking changes** - public API remains identical:
- `delay` option still controls throttling
- Default behavior unchanged (no throttling when `delay` is omitted/undefined)

## Test plan

- [x] Existing tests pass
- [x] New unit tests for `useThrottledDebounce` hook
- [x] Integration test verifies delay option works end-to-end