### PR TITLE
fix(release): use OIDC trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,4 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` and `NODE_AUTH_TOKEN` env vars from the release workflow
- npm CLI will now authenticate via OIDC trusted publishing (configured on npmjs.com) instead of a long-lived access token
- Fixes publish failures caused by expired/OTP-blocked tokens

## Test plan
- [ ] Verify npm trusted publisher config on npmjs.com matches repo exactly (`AVGVSTVS96/react-shiki`, `release.yaml`)
- [ ] Merge this PR and confirm the release workflow publishes `0.9.2` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)