### PR TITLE
ci: fix npm trusted publishing workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,12 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          # npm trusted publishing requires npm >= 11.5.1 and Node >= 22.14.0.
+          # Node 24 ships with npm 11+.
+          node-version: 24
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- update release workflow to use actions/setup-node@v6
- set node version to 24 so npm trusted publishing requirements are met
- remove registry-url from setup-node to avoid token-auth style npm config during publish

## Why
Trusted publishing was configured, but publish auth was still failing with token-style errors. This aligns with using an outdated npm toolchain and registry-url based auth setup in the release job.