### PR TITLE
fix: CSS native layering, use more unique classnames

### DIFF
--- a/.changeset/fix-css-bundling.md
+++ b/.changeset/fix-css-bundling.md
@@ -2,4 +2,4 @@
 "react-shiki": patch
 ---
 
-fix: CSS specificity by utilizing native CSS layers and rename classnames to `rs-` prefixed names (`relative` → `rs-root`, `defaultStyles` → `rs-default-styles`, `languageLabel` → `rs-language-label`) to avoid collisions with utility frameworks like Tailwind.
+fix: CSS specificity by utilizing CSS `@layer base` and rename classnames and line-number CSS variables to `rs-` prefixed names, with legacy selector and variable aliases kept for backwards compatibility until the next release.

--- a/.changeset/fix-css-bundling.md
+++ b/.changeset/fix-css-bundling.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+fix: CSS specificity by utilizing native CSS layers and rename classnames to `rs-` prefixed names (`relative` → `rs-root`, `defaultStyles` → `rs-default-styles`, `languageLabel` → `rs-language-label`) to avoid collisions with utility frameworks like Tailwind.

--- a/package/README.md
+++ b/package/README.md
@@ -457,19 +457,19 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 > import 'react-shiki/css';
 > ```
 > Or provide your own CSS counter implementation and styles for `.rs-line-number` (line `span`) and `.rs-has-line-numbers` (container `code` element).
-> Legacy selectors `.line-numbers` and `.has-line-numbers` are still supported for this release cycle, but are deprecated and will be removed in the next major.
+> Legacy `.line-numbers` / `.has-line-numbers` selectors and unprefixed line-number CSS variables are still supported for this release cycle, but are deprecated and will be removed in the next major.
 
 Component-internal default classes are namespaced under `rs-*` and shipped inside `@layer base` so app-level utilities can override them more predictably.
 
 Available CSS variables for customization:
 ```css
---line-numbers-foreground: rgba(107, 114, 128, 0.5);
---line-numbers-width: 2ch;
---line-numbers-padding-left: 0ch;
---line-numbers-padding-right: 2ch;
---line-numbers-font-size: inherit;
---line-numbers-font-weight: inherit;
---line-numbers-opacity: 1;
+--rs-line-numbers-foreground: rgba(107, 114, 128, 0.5);
+--rs-line-numbers-width: 2ch;
+--rs-line-numbers-padding-left: 0ch;
+--rs-line-numbers-padding-right: 2ch;
+--rs-line-numbers-font-size: inherit;
+--rs-line-numbers-font-weight: inherit;
+--rs-line-numbers-opacity: 1;
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:
@@ -479,8 +479,8 @@ You can customize them in your own CSS or by using the style prop on the compone
   theme="github-dark"
   showLineNumbers
   style={{
-    '--line-numbers-foreground': '#60a5fa',
-    '--line-numbers-width': '3ch'
+    '--rs-line-numbers-foreground': '#60a5fa',
+    '--rs-line-numbers-width': '3ch'
   }}
 >
   {code}

--- a/package/README.md
+++ b/package/README.md
@@ -456,7 +456,10 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 > ```tsx
 > import 'react-shiki/css';
 > ```
-> Or provide your own CSS counter implementation and styles for `.line-numbers` (line `span`) and `.has-line-numbers` (container `code` element)
+> Or provide your own CSS counter implementation and styles for `.rs-line-number` (line `span`) and `.rs-has-line-numbers` (container `code` element).
+> Legacy selectors `.line-numbers` and `.has-line-numbers` are still supported for this release cycle, but are deprecated and will be removed in the next major.
+
+Component-internal default classes are namespaced under `rs-*` and shipped inside `@layer base` so app-level utilities can override them more predictably.
 
 Available CSS variables for customization:
 ```css

--- a/package/package.json
+++ b/package/package.json
@@ -28,10 +28,11 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src/lib/features.css"
+    "src/styles/features.css"
   ],
   "sideEffects": [
-    "src/lib/features.css"
+    "src/styles/component.css",
+    "src/styles/features.css"
   ],
   "publishConfig": {
     "access": "public",
@@ -50,7 +51,7 @@
       "types": "./dist/core.d.ts",
       "default": "./dist/core.js"
     },
-    "./css": "./src/lib/features.css"
+    "./css": "./src/styles/features.css"
   },
   "scripts": {
     "dev": "tsup --watch",

--- a/package/package.json
+++ b/package/package.json
@@ -28,10 +28,10 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src/lib/styles.css"
+    "src/lib/features.css"
   ],
   "sideEffects": [
-    "src/lib/styles.css"
+    "src/lib/features.css"
   ],
   "publishConfig": {
     "access": "public",
@@ -50,7 +50,7 @@
       "types": "./dist/core.d.ts",
       "default": "./dist/core.js"
     },
-    "./css": "./src/lib/styles.css"
+    "./css": "./src/lib/features.css"
   },
   "scripts": {
     "dev": "tsup --watch",

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -156,9 +156,9 @@ export const createShikiHighlighterComponent = (
           ref={ref}
           data-testid="shiki-container"
           className={clsx(
-            'relative',
+            'rs-root',
             'not-prose',
-            addDefaultStyles && 'defaultStyles',
+            addDefaultStyles && 'rs-default-styles',
             className
           )}
           style={style}
@@ -166,7 +166,10 @@ export const createShikiHighlighterComponent = (
         >
           {showLanguage && displayLanguageId ? (
             <span
-              className={clsx('languageLabel', langClassName)}
+              className={clsx(
+                'rs-language-label',
+                langClassName
+              )}
               style={langStyle}
               id="language-label"
             >

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -1,4 +1,5 @@
-import './styles.css';
+import '../styles/component.css';
+import '../styles/features.css';
 import { clsx } from 'clsx';
 
 import type {

--- a/package/src/lib/styles.css
+++ b/package/src/lib/styles.css
@@ -1,55 +1,59 @@
-.relative {
-  position: relative;
-}
+@layer base {
+  .rs-root {
+    position: relative;
+  }
 
-.defaultStyles pre {
-  overflow: auto;
-  border-radius: 0.5rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
-}
+  .rs-default-styles pre {
+    overflow: auto;
+    border-radius: 0.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+  }
 
-.languageLabel {
-  position: absolute;
-  right: 0.75rem;
-  top: 0.5rem;
-  font-family: monospace;
-  font-size: 0.75rem;
-  letter-spacing: -0.05em;
-  color: rgba(107, 114, 128, 0.85);
-}
+  .rs-language-label {
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+    font-family: monospace;
+    font-size: 0.75rem;
+    letter-spacing: -0.05em;
+    color: rgba(107, 114, 128, 0.85);
+  }
 
-.line-numbers::before {
-  counter-increment: line-number;
-  content: counter(line-number);
-  display: inline-flex;
-  justify-content: flex-end;
-  align-items: flex-start;
-  box-sizing: content-box;
-  min-width: var(--line-numbers-width, 2ch);
-  padding-left: var(--line-numbers-padding-left, 2ch);
-  padding-right: var(--line-numbers-padding-right, 2ch);
-  color: var(--line-numbers-foreground, rgba(107, 114, 128, 0.6));
-  font-size: var(--line-numbers-font-size, inherit);
-  font-weight: var(--line-numbers-font-weight, inherit);
-  line-height: var(--line-numbers-line-height, inherit);
-  font-family: var(--line-numbers-font-family, inherit);
-  opacity: var(--line-numbers-opacity, 1);
-  user-select: none;
-  pointer-events: none;
-}
+  .line-numbers::before,
+  .rs-line-number::before {
+    counter-increment: line-number;
+    content: counter(line-number);
+    display: inline-flex;
+    justify-content: flex-end;
+    align-items: flex-start;
+    box-sizing: content-box;
+    min-width: var(--line-numbers-width, 2ch);
+    padding-left: var(--line-numbers-padding-left, 2ch);
+    padding-right: var(--line-numbers-padding-right, 2ch);
+    color: var(--line-numbers-foreground, rgba(107, 114, 128, 0.6));
+    font-size: var(--line-numbers-font-size, inherit);
+    font-weight: var(--line-numbers-font-weight, inherit);
+    line-height: var(--line-numbers-line-height, inherit);
+    font-family: var(--line-numbers-font-family, inherit);
+    opacity: var(--line-numbers-opacity, 1);
+    user-select: none;
+    pointer-events: none;
+  }
 
-.has-line-numbers {
-  counter-reset: line-number calc(var(--line-start, 1) - 1);
-  --line-numbers-foreground: rgba(107, 114, 128, 0.5);
-  --line-numbers-width: 2ch;
-  --line-numbers-padding-left: 0ch;
-  --line-numbers-padding-right: 2ch;
-  --line-numbers-font-size: inherit;
-  --line-numbers-font-weight: inherit;
-  --line-numbers-line-height: inherit;
-  --line-numbers-font-family: inherit;
-  --line-numbers-opacity: 1;
+  .has-line-numbers,
+  .rs-has-line-numbers {
+    counter-reset: line-number calc(var(--line-start, 1) - 1);
+    --line-numbers-foreground: rgba(107, 114, 128, 0.5);
+    --line-numbers-width: 2ch;
+    --line-numbers-padding-left: 0ch;
+    --line-numbers-padding-right: 2ch;
+    --line-numbers-font-size: inherit;
+    --line-numbers-font-weight: inherit;
+    --line-numbers-line-height: inherit;
+    --line-numbers-font-family: inherit;
+    --line-numbers-opacity: 1;
+  }
 }

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -9,6 +9,7 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
     name: 'react-shiki:line-numbers',
     code(node) {
       this.addClassToHast(node, 'has-line-numbers');
+      this.addClassToHast(node, 'rs-has-line-numbers');
       if (startLine !== 1) {
         const existingStyle = (node.properties?.style as string) || '';
         const newStyle = existingStyle
@@ -22,6 +23,7 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
     },
     line(node) {
       this.addClassToHast(node, 'line-numbers');
+      this.addClassToHast(node, 'rs-line-number');
       return node;
     },
   };

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -1,0 +1,24 @@
+@layer base {
+  .rs-root {
+    position: relative;
+  }
+
+  .rs-default-styles pre {
+    overflow: auto;
+    border-radius: 0.5rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+  }
+
+  .rs-language-label {
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+    font-family: monospace;
+    font-size: 0.75rem;
+    letter-spacing: -0.05em;
+    color: rgba(107, 114, 128, 0.85);
+  }
+}

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -1,27 +1,4 @@
 @layer base {
-  .rs-root {
-    position: relative;
-  }
-
-  .rs-default-styles pre {
-    overflow: auto;
-    border-radius: 0.5rem;
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-    padding-top: 1.25rem;
-    padding-bottom: 1.25rem;
-  }
-
-  .rs-language-label {
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
-    font-family: monospace;
-    font-size: 0.75rem;
-    letter-spacing: -0.05em;
-    color: rgba(107, 114, 128, 0.85);
-  }
-
   .line-numbers::before,
   .rs-line-number::before {
     counter-increment: line-number;

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -7,15 +7,15 @@
     justify-content: flex-end;
     align-items: flex-start;
     box-sizing: content-box;
-    min-width: var(--line-numbers-width, 2ch);
-    padding-left: var(--line-numbers-padding-left, 2ch);
-    padding-right: var(--line-numbers-padding-right, 2ch);
-    color: var(--line-numbers-foreground, rgba(107, 114, 128, 0.6));
-    font-size: var(--line-numbers-font-size, inherit);
-    font-weight: var(--line-numbers-font-weight, inherit);
-    line-height: var(--line-numbers-line-height, inherit);
-    font-family: var(--line-numbers-font-family, inherit);
-    opacity: var(--line-numbers-opacity, 1);
+    min-width: var(--rs-line-numbers-width, 2ch);
+    padding-left: var(--rs-line-numbers-padding-left, 2ch);
+    padding-right: var(--rs-line-numbers-padding-right, 2ch);
+    color: var(--rs-line-numbers-foreground, rgba(107, 114, 128, 0.6));
+    font-size: var(--rs-line-numbers-font-size, inherit);
+    font-weight: var(--rs-line-numbers-font-weight, inherit);
+    line-height: var(--rs-line-numbers-line-height, inherit);
+    font-family: var(--rs-line-numbers-font-family, inherit);
+    opacity: var(--rs-line-numbers-opacity, 1);
     user-select: none;
     pointer-events: none;
   }
@@ -23,14 +23,14 @@
   .has-line-numbers,
   .rs-has-line-numbers {
     counter-reset: line-number calc(var(--line-start, 1) - 1);
-    --line-numbers-foreground: rgba(107, 114, 128, 0.5);
-    --line-numbers-width: 2ch;
-    --line-numbers-padding-left: 0ch;
-    --line-numbers-padding-right: 2ch;
-    --line-numbers-font-size: inherit;
-    --line-numbers-font-weight: inherit;
-    --line-numbers-line-height: inherit;
-    --line-numbers-font-family: inherit;
-    --line-numbers-opacity: 1;
+    --rs-line-numbers-foreground: var(--line-numbers-foreground, rgba(107, 114, 128, 0.5));
+    --rs-line-numbers-width: var(--line-numbers-width, 2ch);
+    --rs-line-numbers-padding-left: var(--line-numbers-padding-left, 0ch);
+    --rs-line-numbers-padding-right: var(--line-numbers-padding-right, 2ch);
+    --rs-line-numbers-font-size: var(--line-numbers-font-size, inherit);
+    --rs-line-numbers-font-weight: var(--line-numbers-font-weight, inherit);
+    --rs-line-numbers-line-height: var(--line-numbers-line-height, inherit);
+    --rs-line-numbers-font-family: var(--line-numbers-font-family, inherit);
+    --rs-line-numbers-opacity: var(--line-numbers-opacity, 1);
   }
 }

--- a/package/tests/component.test.tsx
+++ b/package/tests/component.test.tsx
@@ -30,6 +30,9 @@ describe('ShikiHighlighter Component', () => {
         const containerElement = getContainer(container);
         expect(containerElement).toBeInTheDocument();
         expect(containerElement?.tagName.toLowerCase()).toBe('pre');
+        expect(containerElement).toHaveClass('rs-root');
+        expect(containerElement).toHaveClass('rs-default-styles');
+        expect(containerElement).not.toHaveClass('relative');
       });
     });
 
@@ -65,6 +68,7 @@ describe('ShikiHighlighter Component', () => {
         expect(langLabel).toBeInTheDocument();
         expect(langLabel?.textContent).toBe('javascript');
         expect(langLabel?.id).toBe('language-label');
+        expect(langLabel).toHaveClass('rs-language-label');
       });
     });
 
@@ -161,6 +165,7 @@ describe('ShikiHighlighter Component', () => {
       await waitFor(() => {
         const outerContainer = getContainer(container);
         expect(outerContainer?.className).toContain('custom-code-block');
+        expect(outerContainer).toHaveClass('rs-root');
       });
     });
 
@@ -210,6 +215,7 @@ describe('ShikiHighlighter Component', () => {
 
         expect(langLabel).toHaveStyle('color: rgb(0, 0, 255)');
         expect(langLabel?.className).toContain('custom-lang-label');
+        expect(langLabel).toHaveClass('rs-language-label');
       });
     });
 

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -259,9 +259,14 @@ describe('useShikiHighlighter Hook', () => {
         const container = getByTestId('highlighted');
         const codeElement = container.querySelector('code');
         expect(codeElement).not.toHaveClass('has-line-numbers');
+        expect(codeElement).not.toHaveClass('rs-has-line-numbers');
 
         const lineElements = container.querySelectorAll('.line-numbers');
         expect(lineElements).toHaveLength(0);
+
+        const rsLineElements =
+          container.querySelectorAll('.rs-line-number');
+        expect(rsLineElements).toHaveLength(0);
       });
     });
 
@@ -276,9 +281,14 @@ describe('useShikiHighlighter Hook', () => {
         const container = getByTestId('highlighted');
         const codeElement = container.querySelector('code');
         expect(codeElement).toHaveClass('has-line-numbers');
+        expect(codeElement).toHaveClass('rs-has-line-numbers');
 
         const lineElements = container.querySelectorAll('.line-numbers');
         expect(lineElements.length).toBeGreaterThan(0);
+
+        const rsLineElements =
+          container.querySelectorAll('.rs-line-number');
+        expect(rsLineElements.length).toBe(lineElements.length);
       });
     });
 


### PR DESCRIPTION
### CSS Class Namespace Migration

- Introduced new CSS class names prefixed with `rs-` for better namespace isolation:
    - `.relative` → `.rs-root`
    - `.defaultStyles` → `.rs-default-styles`
    - `.languageLabel` → `.rs-language-label`
    - `.line-numbers` → `.rs-line-number`
    - `.has-line-numbers` → `.rs-has-line-numbers`
- Legacy class names (`.line-numbers`, `.has-line-numbers`) remain supported alongside new prefixed classes for backward compatibility but are deprecated and will be removed in the next major release
- Refactored CSS architecture by splitting `styles.css` into separate files:
    - `component.css` for core component styles
    - `features.css` for feature-specific styles like line numbers
    - All styles now wrapped in `@layer base` for better CSS cascade control
- Updated package exports to reference new `features.css` file path