### PR TITLE
feat: add experimental `outputFormat: 'tokens'` support

### DIFF
--- a/.changeset/token-output-format.md
+++ b/.changeset/token-output-format.md
@@ -1,5 +1,5 @@
 ---
-"react-shiki": minor
+"react-shiki": patch
 ---
 
 Add hook-only `outputFormat: "tokens"` support for returning Shiki token output.

--- a/.changeset/token-output-format.md
+++ b/.changeset/token-output-format.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": minor
+---
+
+Add hook-only `outputFormat: "tokens"` support for returning Shiki token output.

--- a/.changeset/token-output-format.md
+++ b/.changeset/token-output-format.md
@@ -1,5 +1,7 @@
 ---
-"react-shiki": minor
+"react-shiki": patch
 ---
 
-Add experimental `outputFormat: 'tokens'` support to `useShikiHighlighter` for returning Shiki's raw token output (`TokensResult`) for custom rendering. Hook-only: the `ShikiHighlighter` component excludes it at the type level and falls back to `'react'` with a console warning if passed at runtime. The hook's return type now narrows based on the `outputFormat` passed (`'react'` → `ReactElement`, `'html'` → `string`, `'tokens'` → `TokensResult`).
+Add experimental `outputFormat: 'tokens'` support to `useShikiHighlighter`, returning Shiki's raw `TokensResult` for custom rendering. The hook's return type narrows based on the literal `outputFormat` passed: `'react'` returns `ReactElement`, `'html'` returns `string`, and `'tokens'` returns `TokensResult`.
+
+Token output is hook-only. `'tokens'` is accepted through the hook's generic signature but excluded from `HighlighterOptions` and the component's props, so existing option objects and wrappers keep their current types. The `ShikiHighlighter` component warns and falls back to `'react'` if `'tokens'` is passed at runtime.

--- a/.changeset/token-output-format.md
+++ b/.changeset/token-output-format.md
@@ -1,5 +1,5 @@
 ---
-"react-shiki": patch
+"react-shiki": minor
 ---
 
-Add hook-only `outputFormat: "tokens"` support for returning Shiki token output.
+Add experimental `outputFormat: 'tokens'` support to `useShikiHighlighter` for returning Shiki's raw token output (`TokensResult`) for custom rendering. Hook-only: the `ShikiHighlighter` component excludes it at the type level and falls back to `'react'` with a console warning if passed at runtime. The hook's return type now narrows based on the `outputFormat` passed (`'react'` → `ReactElement`, `'html'` → `string`, `'tokens'` → `TokensResult`).

--- a/.changeset/token-output-format.md
+++ b/.changeset/token-output-format.md
@@ -1,5 +1,5 @@
 ---
-"react-shiki": patch
+"react-shiki": minor
 ---
 
 Add experimental `outputFormat: 'tokens'` support to `useShikiHighlighter`, returning Shiki's raw `TokensResult` for custom rendering. The hook's return type narrows based on the literal `outputFormat` passed: `'react'` returns `ReactElement`, `'html'` returns `string`, and `'tokens'` returns `TokensResult`.

--- a/package/README.md
+++ b/package/README.md
@@ -222,7 +222,7 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
 | `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
 | `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |
-| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens in the hook |
+| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens (hook only, experimental) |
 | `tabindex`          | `number`           | `0`             | Tab index for the code block                                                  |
 | `decorations`       | `array`            | `[]`            | Custom decorations to wrap the highlighted tokens with                        |
 | `structure`        | `string`           | `'classic'`  | The structure of the generated HAST and HTML - `classic` or `inline`               |

--- a/package/README.md
+++ b/package/README.md
@@ -677,7 +677,7 @@ The React and HTML formats spend their rendering work in different phases. HTML 
 
 HTML output hands the highlighted markup to the DOM via `dangerouslySetInnerHTML`, so only use it with trusted code sources. The default React output is the safe choice for untrusted content.
 
-Token output is for when you need to own rendering yourself; it is intentionally available on the hook, not the `ShikiHighlighter` component, since react-shiki's markup-based features no longer apply once you control the markup. Note that transformers and decorations run in the HAST pipeline that token output bypasses, so they have no effect on token output.
+Token output is for when you need to own rendering yourself; it is intentionally available on the hook, not the `ShikiHighlighter` component, since react-shiki's markup-based features no longer apply once you control the markup. Note that Shiki's `codeToTokens` does not run transformers or decorations, so markup-producing options, including transformers, decorations, line numbers, and `structure`, have no effect on token output.
 
 ---
 

--- a/package/README.md
+++ b/package/README.md
@@ -222,7 +222,7 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
 | `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
 | `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |
-| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string                 |
+| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens in the hook |
 | `tabindex`          | `number`           | `0`             | Tab index for the code block                                                  |
 | `decorations`       | `array`            | `[]`            | Custom decorations to wrap the highlighted tokens with                        |
 | `structure`        | `string`           | `'classic'`  | The structure of the generated HAST and HTML - `classic` or `inline`               |
@@ -630,7 +630,7 @@ const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
 
 ### Output Formats
 
-`react-shiki` can return highlighted code in two formats:
+`react-shiki` can return highlighted code in three formats:
 
 **React Nodes (Default)** - Rendered as React elements, no `dangerouslySetInnerHTML` required
 ```tsx
@@ -656,9 +656,28 @@ const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
 </ShikiHighlighter>
 ```
 
-The two formats spend their rendering work in different phases. HTML output skips per-token React element creation and reconciliation, reducing render-phase overhead for large, one-shot highlights, but each update replaces the code block's entire DOM subtree via `innerHTML`. React output pays for element creation and diffing on every update, but commits only incremental DOM mutations, minimizing DOM churn for frequently re-highlighted code such as streaming LLM output.
+**Shiki Tokens (Experimental)** - Hook-only output for custom renderers
+```tsx
+const highlighted = useShikiHighlighter(code, "tsx", "github-dark", {
+  outputFormat: "tokens",
+});
+
+const rendered = highlighted?.tokens.map((line, i) => (
+  <div key={i}>
+    {line.map((token, j) => (
+      <span key={j} style={{ color: token.color }}>
+        {token.content}
+      </span>
+    ))}
+  </div>
+));
+```
+
+The React and HTML formats spend their rendering work in different phases. HTML output skips per-token React element creation and reconciliation, reducing render-phase overhead for large, one-shot highlights, but each update replaces the code block's entire DOM subtree via `innerHTML`. React output pays for element creation and diffing on every update, but commits only incremental DOM mutations, minimizing DOM churn for frequently re-highlighted code such as streaming LLM output.
 
 HTML output hands the highlighted markup to the DOM via `dangerouslySetInnerHTML`, so only use it with trusted code sources. The default React output is the safe choice for untrusted content.
+
+Token output is for when you need to own rendering yourself; it is intentionally available on the hook, not the `ShikiHighlighter` component, since react-shiki's markup-based features no longer apply once you control the markup. Note that transformers and decorations run in the HAST pipeline that token output bypasses, so they have no effect on token output.
 
 ---
 

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -1,6 +1,13 @@
 import { useHighlight } from './lib/hook';
 import { validateCoreHighlighter } from './bundles/core';
-import type { UseShikiHighlighter } from './lib/types';
+import type {
+  BaseHighlighterOptions,
+  Language,
+  OutputFormat,
+  Theme,
+  Themes,
+  UseShikiHighlighter,
+} from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -62,16 +69,18 @@ export type { LanguageRegistration } from 'shiki/core';
  *
  * Core bundle (minimal). For plug-and-play: `react-shiki` or `react-shiki/web`
  */
-export const useShikiHighlighter: UseShikiHighlighter = (
-  code,
-  lang,
-  themeInput,
-  options = {}
+export const useShikiHighlighter: UseShikiHighlighter = <
+  F extends OutputFormat = 'react',
+>(
+  code: string,
+  lang: Language,
+  themeInput: Theme | Themes,
+  options: BaseHighlighterOptions & { outputFormat?: F } = {}
 ) => {
   // Validate that highlighter is provided
   const highlighter = validateCoreHighlighter(options.highlighter);
 
-  return useHighlight(
+  return useHighlight<F>(
     code,
     lang,
     themeInput,

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -1,13 +1,6 @@
 import { useHighlight } from './lib/hook';
 import { validateCoreHighlighter } from './bundles/core';
-import type {
-  HighlighterOptionsFor,
-  Language,
-  OutputFormat,
-  Theme,
-  Themes,
-  UseShikiHighlighter,
-} from './lib/types';
+import type { UseShikiHighlighter } from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -72,18 +65,16 @@ export type { LanguageRegistration, TokensResult } from 'shiki/core';
  *
  * Core bundle (minimal). For plug-and-play: `react-shiki` or `react-shiki/web`
  */
-export const useShikiHighlighter: UseShikiHighlighter = <
-  F extends OutputFormat = 'react',
->(
-  code: string,
-  lang: Language,
-  themeInput: Theme | Themes,
-  options: HighlighterOptionsFor<F> = {}
+export const useShikiHighlighter: UseShikiHighlighter = (
+  code,
+  lang,
+  themeInput,
+  options = {}
 ) => {
   // Validate that highlighter is provided
   const highlighter = validateCoreHighlighter(options.highlighter);
 
-  return useHighlight<F>(
+  return useHighlight(
     code,
     lang,
     themeInput,

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -1,7 +1,7 @@
 import { useHighlight } from './lib/hook';
 import { validateCoreHighlighter } from './bundles/core';
 import type {
-  BaseHighlighterOptions,
+  HighlighterOptionsFor,
   Language,
   OutputFormat,
   Theme,
@@ -75,7 +75,7 @@ export const useShikiHighlighter: UseShikiHighlighter = <
   code: string,
   lang: Language,
   themeInput: Theme | Themes,
-  options: BaseHighlighterOptions & { outputFormat?: F } = {}
+  options: HighlighterOptionsFor<F> = {}
 ) => {
   // Validate that highlighter is provided
   const highlighter = validateCoreHighlighter(options.highlighter);

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -25,6 +25,9 @@ export type {
   Themes,
   Element,
   HighlighterOptions,
+  HighlighterOptionsFor,
+  HighlightResult,
+  OutputFormat,
 } from './lib/types';
 
 export { createHighlighterCore } from 'shiki/core';
@@ -34,7 +37,7 @@ export {
   createJavaScriptRawEngine,
 } from 'shiki/engine/javascript';
 
-export type { LanguageRegistration } from 'shiki/core';
+export type { LanguageRegistration, TokensResult } from 'shiki/core';
 
 /**
  * Highlight code with shiki (core bundle)
@@ -43,7 +46,7 @@ export type { LanguageRegistration } from 'shiki/core';
  * @param lang - Language (bundled or custom)
  * @param theme - Theme (bundled, multi-theme, or custom)
  * @param options - react-shiki options + shiki options
- * @returns Highlighted code as React elements or HTML string
+ * @returns Highlighted code as React elements (default), HTML string, or Shiki tokens, based on `outputFormat`
  *
  * @example
  * ```tsx

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,4 +1,4 @@
-import { useHighlight } from './lib/hook';
+import { createUseShikiHighlighter } from './lib/hook';
 import { createFullHighlighter } from './bundles/full';
 import type { UseShikiHighlighter } from './lib/types';
 
@@ -50,20 +50,8 @@ export type { LanguageRegistration } from 'shiki';
  *
  * Full bundle (~6.4MB minified, 1.2MB gzipped). For smaller bundles: `react-shiki/web` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter = (
-  code,
-  lang,
-  themeInput,
-  options = {}
-) => {
-  return useHighlight(
-    code,
-    lang,
-    themeInput,
-    options,
-    createFullHighlighter
-  );
-};
+export const useShikiHighlighter: UseShikiHighlighter =
+  createUseShikiHighlighter(createFullHighlighter);
 
 /**
  * ShikiHighlighter component using the full bundle.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,6 +1,13 @@
-import { createUseShikiHighlighter } from './lib/hook';
+import { useHighlight } from './lib/hook';
 import { createFullHighlighter } from './bundles/full';
-import type { UseShikiHighlighter } from './lib/types';
+import type {
+  HighlighterOptionsFor,
+  Language,
+  OutputFormat,
+  Theme,
+  Themes,
+  UseShikiHighlighter,
+} from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -50,8 +57,15 @@ export type { LanguageRegistration } from 'shiki';
  *
  * Full bundle (~6.4MB minified, 1.2MB gzipped). For smaller bundles: `react-shiki/web` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter =
-  createUseShikiHighlighter(createFullHighlighter);
+export const useShikiHighlighter: UseShikiHighlighter = <
+  F extends OutputFormat = 'react',
+>(
+  code: string,
+  lang: Language,
+  themeInput: Theme | Themes,
+  options: HighlighterOptionsFor<F> = {}
+) =>
+  useHighlight<F>(code, lang, themeInput, options, createFullHighlighter);
 
 /**
  * ShikiHighlighter component using the full bundle.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,13 +1,6 @@
 import { useHighlight } from './lib/hook';
 import { createFullHighlighter } from './bundles/full';
-import type {
-  HighlighterOptionsFor,
-  Language,
-  OutputFormat,
-  Theme,
-  Themes,
-  UseShikiHighlighter,
-} from './lib/types';
+import type { UseShikiHighlighter } from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -60,15 +53,12 @@ export type { LanguageRegistration, TokensResult } from 'shiki';
  *
  * Full bundle (~6.4MB minified, 1.2MB gzipped). For smaller bundles: `react-shiki/web` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter = <
-  F extends OutputFormat = 'react',
->(
-  code: string,
-  lang: Language,
-  themeInput: Theme | Themes,
-  options: HighlighterOptionsFor<F> = {}
-) =>
-  useHighlight<F>(code, lang, themeInput, options, createFullHighlighter);
+export const useShikiHighlighter: UseShikiHighlighter = (
+  code,
+  lang,
+  themeInput,
+  options = {}
+) => useHighlight(code, lang, themeInput, options, createFullHighlighter);
 
 /**
  * ShikiHighlighter component using the full bundle.

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -25,6 +25,9 @@ export type {
   Themes,
   Element,
   HighlighterOptions,
+  HighlighterOptionsFor,
+  HighlightResult,
+  OutputFormat,
 } from './lib/types';
 
 export {
@@ -32,7 +35,7 @@ export {
   createJavaScriptRawEngine,
 } from 'shiki/engine/javascript';
 
-export type { LanguageRegistration } from 'shiki';
+export type { LanguageRegistration, TokensResult } from 'shiki';
 
 /**
  * Highlight code with shiki (full bundle)
@@ -41,7 +44,7 @@ export type { LanguageRegistration } from 'shiki';
  * @param lang - Language (bundled or custom)
  * @param theme - Theme (bundled, multi-theme, or custom)
  * @param options - react-shiki options + shiki options
- * @returns Highlighted code as React elements or HTML string
+ * @returns Highlighted code as React elements (default), HTML string, or Shiki tokens, based on `outputFormat`
  *
  * @example
  * ```tsx

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -129,11 +129,12 @@ export const createShikiHighlighterComponent = (
         as: Element = 'div',
         customLanguages,
         preloadLanguages,
+        outputFormat,
         ...shikiOptions
       },
       ref
     ) => {
-      // Destructure some options for use in hook
+
       const options: ComponentHighlighterOptions = {
         delay,
         transformers,
@@ -144,29 +145,22 @@ export const createShikiHighlighterComponent = (
         cssVariablePrefix,
         startingLineNumber,
         highlightLineNumbers,
+        outputFormat,
         ...shikiOptions,
       };
-
-      if (
-        (options as { outputFormat?: string }).outputFormat === 'tokens'
-      ) {
-        throw new Error(
-          '[react-shiki] outputFormat: "tokens" is hook-only. ' +
-            'Use useShikiHighlighter directly to render tokens.'
-        );
-      }
 
       const displayLanguageId =
         typeof language === 'object'
           ? language.name || null
           : language?.trim() || null;
 
-      const highlightedCode = useShikiHighlighterImpl<ComponentOutputFormat>(
-        code,
-        language,
-        theme,
-        options
-      );
+      const highlightedCode =
+        useShikiHighlighterImpl<ComponentOutputFormat>(
+          code,
+          language,
+          theme,
+          options
+        );
 
       return (
         <Element

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -6,11 +6,33 @@ import type {
   ComponentHighlighterOptions,
   ComponentOutputFormat,
   Language,
+  OutputFormat,
   Theme,
   Themes,
   UseShikiHighlighter,
 } from './types';
 import { forwardRef } from 'react';
+
+let warnedTokensOutputFormat = false;
+
+/**
+ * The component's types exclude `outputFormat: 'tokens'`, but plain-JS
+ * callers can still pass it. Tokens are not renderable React children,
+ * so fall back to 'react' instead of crashing the render.
+ */
+const resolveOutputFormat = (
+  outputFormat: ComponentOutputFormat | undefined
+): ComponentOutputFormat | undefined => {
+  if ((outputFormat as OutputFormat) !== 'tokens') return outputFormat;
+
+  if (!warnedTokensOutputFormat) {
+    warnedTokensOutputFormat = true;
+    console.warn(
+      "[react-shiki] outputFormat 'tokens' is only supported by the useShikiHighlighter hook, falling back to 'react'"
+    );
+  }
+  return 'react';
+};
 
 /**
  * Props for the ShikiHighlighter component
@@ -134,7 +156,6 @@ export const createShikiHighlighterComponent = (
       },
       ref
     ) => {
-
       const options: ComponentHighlighterOptions = {
         delay,
         transformers,
@@ -145,7 +166,7 @@ export const createShikiHighlighterComponent = (
         cssVariablePrefix,
         startingLineNumber,
         highlightLineNumbers,
-        outputFormat,
+        outputFormat: resolveOutputFormat(outputFormat),
         ...shikiOptions,
       };
 

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -3,7 +3,8 @@ import '../styles/features.css';
 import { clsx } from 'clsx';
 
 import type {
-  HighlighterOptions,
+  ComponentHighlighterOptions,
+  ComponentOutputFormat,
   Language,
   Theme,
   Themes,
@@ -14,7 +15,8 @@ import { forwardRef } from 'react';
 /**
  * Props for the ShikiHighlighter component
  */
-export interface ShikiHighlighterProps extends HighlighterOptions {
+export interface ShikiHighlighterProps
+  extends ComponentHighlighterOptions {
   /**
    * The programming language for syntax highlighting
    * Supports custom textmate grammar objects in addition to Shiki's bundled languages
@@ -132,7 +134,7 @@ export const createShikiHighlighterComponent = (
       ref
     ) => {
       // Destructure some options for use in hook
-      const options: HighlighterOptions = {
+      const options: ComponentHighlighterOptions = {
         delay,
         transformers,
         customLanguages,
@@ -145,12 +147,21 @@ export const createShikiHighlighterComponent = (
         ...shikiOptions,
       };
 
+      if (
+        (options as { outputFormat?: string }).outputFormat === 'tokens'
+      ) {
+        throw new Error(
+          '[react-shiki] outputFormat: "tokens" is hook-only. ' +
+            'Use useShikiHighlighter directly to render tokens.'
+        );
+      }
+
       const displayLanguageId =
         typeof language === 'object'
           ? language.name || null
           : language?.trim() || null;
 
-      const highlightedCode = useShikiHighlighterImpl(
+      const highlightedCode = useShikiHighlighterImpl<ComponentOutputFormat>(
         code,
         language,
         theme,

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -3,8 +3,7 @@ import '../styles/features.css';
 import { clsx } from 'clsx';
 
 import type {
-  ComponentHighlighterOptions,
-  ComponentOutputFormat,
+  HighlighterOptions,
   Language,
   OutputFormat,
   Theme,
@@ -16,13 +15,13 @@ import { forwardRef } from 'react';
 let warnedTokensOutputFormat = false;
 
 /**
- * The component's types exclude `outputFormat: 'tokens'`, but plain-JS
+ * The component's props exclude `outputFormat: 'tokens'`, but plain-JS
  * callers can still pass it. Tokens are not renderable React children,
  * so fall back to 'react' instead of crashing the render.
  */
 const resolveOutputFormat = (
-  outputFormat: ComponentOutputFormat | undefined
-): ComponentOutputFormat | undefined => {
+  outputFormat: HighlighterOptions['outputFormat']
+): HighlighterOptions['outputFormat'] => {
   if ((outputFormat as OutputFormat) !== 'tokens') return outputFormat;
 
   if (!warnedTokensOutputFormat) {
@@ -37,8 +36,7 @@ const resolveOutputFormat = (
 /**
  * Props for the ShikiHighlighter component
  */
-export interface ShikiHighlighterProps
-  extends ComponentHighlighterOptions {
+export interface ShikiHighlighterProps extends HighlighterOptions {
   /**
    * The programming language for syntax highlighting
    * Supports custom textmate grammar objects in addition to Shiki's bundled languages
@@ -156,7 +154,7 @@ export const createShikiHighlighterComponent = (
       },
       ref
     ) => {
-      const options: ComponentHighlighterOptions = {
+      const options: HighlighterOptions = {
         delay,
         transformers,
         customLanguages,
@@ -175,13 +173,12 @@ export const createShikiHighlighterComponent = (
           ? language.name || null
           : language?.trim() || null;
 
-      const highlightedCode =
-        useShikiHighlighterImpl<ComponentOutputFormat>(
-          code,
-          language,
-          theme,
-          options
-        );
+      const highlightedCode = useShikiHighlighterImpl(
+        code,
+        language,
+        theme,
+        options
+      );
 
       return (
         <Element

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -69,7 +69,9 @@ export async function highlight<F extends OutputFormat = 'react'>(
     tokens: () => highlighter.codeToTokens(code, options),
   };
 
-  return outputs[format]() as HighlightResultMap[F];
+  // Untyped call sites can pass formats outside OutputFormat; degrade to
+  // react rendering like the pre-tokens ternary did instead of throwing.
+  return (outputs[format] ?? outputs.react)() as HighlightResultMap[F];
 }
 
 export const useHighlight = <F extends OutputFormat = 'react'>(

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -4,16 +4,16 @@ import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import type { CodeToHastOptions } from 'shiki';
 
 import type {
-  BaseHighlighterOptions,
   HighlighterFactory,
   HighlighterOptions,
+  HighlighterOptionsFor,
+  HighlightResult,
   HighlightResultMap,
   Language,
   OutputFormat,
   Theme,
   Themes,
   TimeoutState,
-  UseShikiHighlighter,
 } from './types';
 
 import { throttleHighlighting, useStableValue } from './utils';
@@ -76,12 +76,11 @@ export const useHighlight = <F extends OutputFormat = 'react'>(
   code: string,
   lang: Language,
   themeInput: Theme | Themes,
-  options: BaseHighlighterOptions & { outputFormat?: F } = {},
+  options: HighlighterOptionsFor<F> = {},
   highlighterFactory: HighlighterFactory
-): HighlightResultMap[F] | null => {
-  const [highlightedCode, setHighlightedCode] = useState<
-    HighlightResultMap[F] | null
-  >(null);
+): HighlightResult<F> => {
+  const [highlightedCode, setHighlightedCode] =
+    useState<HighlightResult<F>>(null);
 
   const stableLang = useStableValue(lang);
   const stableTheme = useStableValue(themeInput);
@@ -151,19 +150,4 @@ export const useHighlight = <F extends OutputFormat = 'react'>(
   }, [code, resolved, stableOpts]);
 
   return highlightedCode;
-};
-
-/**
- * Create a `useShikiHighlighter` hook bound to a specific highlighter factory.
- * Used by the bundled entry points (full / web / core).
- */
-export const createUseShikiHighlighter = (
-  factory: HighlighterFactory
-): UseShikiHighlighter => {
-  return <F extends OutputFormat = 'react'>(
-    code: string,
-    lang: Language,
-    themeInput: Theme | Themes,
-    options?: BaseHighlighterOptions & { outputFormat?: F }
-  ) => useHighlight<F>(code, lang, themeInput, options, factory);
 };

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -4,13 +4,16 @@ import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import type { CodeToHastOptions } from 'shiki';
 
 import type {
-  HighlightedCode,
+  BaseHighlighterOptions,
   HighlighterFactory,
   HighlighterOptions,
+  HighlightResultMap,
   Language,
+  OutputFormat,
   Theme,
   Themes,
   TimeoutState,
+  UseShikiHighlighter,
 } from './types';
 
 import { throttleHighlighting, useStableValue } from './utils';
@@ -22,7 +25,7 @@ import {
 import { resolveTheme } from './theme';
 import { buildShikiOptions } from './options';
 
-export async function highlight(
+export async function highlight<F extends OutputFormat = 'react'>(
   code: string,
   resolved: {
     languageId: string;
@@ -30,14 +33,14 @@ export async function highlight(
     themesToLoad: Theme[];
     shikiOptions: CodeToHastOptions;
   },
-  opts: Pick<
-    HighlighterOptions,
-    'highlighter' | 'outputFormat' | 'engine'
-  >,
+  opts: Pick<HighlighterOptions, 'highlighter' | 'engine'> & {
+    outputFormat?: F;
+  },
   factory: HighlighterFactory
-) {
+): Promise<HighlightResultMap[F]> {
   const { languageId, langsToLoad, themesToLoad, shikiOptions } =
     resolved;
+  const format: OutputFormat = opts.outputFormat ?? 'react';
 
   const highlighter =
     opts.highlighter ??
@@ -55,24 +58,30 @@ export async function highlight(
   );
   const options = { ...shikiOptions, lang: language };
 
-  return opts.outputFormat === 'html'
-    ? highlighter.codeToHtml(code, options)
-    : toJsxRuntime(highlighter.codeToHast(code, options), {
+  const outputs: { [K in OutputFormat]: () => HighlightResultMap[K] } = {
+    react: () =>
+      toJsxRuntime(highlighter.codeToHast(code, options), {
         jsx,
         jsxs,
         Fragment,
-      });
+      }),
+    html: () => highlighter.codeToHtml(code, options),
+    tokens: () => highlighter.codeToTokens(code, options),
+  };
+
+  return outputs[format]() as HighlightResultMap[F];
 }
 
-export const useHighlight = (
+export const useHighlight = <F extends OutputFormat = 'react'>(
   code: string,
   lang: Language,
   themeInput: Theme | Themes,
-  options: HighlighterOptions = {},
+  options: BaseHighlighterOptions & { outputFormat?: F } = {},
   highlighterFactory: HighlighterFactory
-) => {
-  const [highlightedCode, setHighlightedCode] =
-    useState<HighlightedCode>(null);
+): HighlightResultMap[F] | null => {
+  const [highlightedCode, setHighlightedCode] = useState<
+    HighlightResultMap[F] | null
+  >(null);
 
   const stableLang = useStableValue(lang);
   const stableTheme = useStableValue(themeInput);
@@ -116,7 +125,7 @@ export const useHighlight = (
 
     const run = async () => {
       try {
-        const result = await highlight(
+        const result = await highlight<F>(
           code,
           resolved,
           stableOpts,
@@ -142,4 +151,19 @@ export const useHighlight = (
   }, [code, resolved, stableOpts]);
 
   return highlightedCode;
+};
+
+/**
+ * Create a `useShikiHighlighter` hook bound to a specific highlighter factory.
+ * Used by the bundled entry points (full / web / core).
+ */
+export const createUseShikiHighlighter = (
+  factory: HighlighterFactory
+): UseShikiHighlighter => {
+  return <F extends OutputFormat = 'react'>(
+    code: string,
+    lang: Language,
+    themeInput: Theme | Themes,
+    options?: BaseHighlighterOptions & { outputFormat?: F }
+  ) => useHighlight<F>(code, lang, themeInput, options, factory);
 };

--- a/package/src/lib/options.ts
+++ b/package/src/lib/options.ts
@@ -5,7 +5,11 @@ import type {
   CodeToHastOptions,
 } from 'shiki';
 
-import type { HighlighterOptions } from './types';
+import type {
+  HighlighterOptions,
+  HighlighterOptionsFor,
+  OutputFormat,
+} from './types';
 import type { ResolvedTheme } from './theme';
 import {
   highlightedLinesTransformer,
@@ -35,7 +39,7 @@ const buildThemeOptions = (
 export const buildShikiOptions = (
   languageId: string,
   resolvedTheme: ResolvedTheme,
-  options: HighlighterOptions
+  options: HighlighterOptionsFor<OutputFormat>
 ): CodeToHastOptions => {
   const {
     delay,

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -88,10 +88,14 @@ interface ReactShikiOptions {
    * Output format for the highlighted code.
    * - 'react': Returns React nodes (default, safer)
    * - 'html': Returns HTML string (rendered via dangerouslySetInnerHTML)
-   * - 'tokens': Returns Shiki tokens for custom rendering (hook only)
+   *
+   * The hook additionally accepts 'tokens' (experimental) to return raw
+   * Shiki tokens for custom rendering. It is deliberately excluded here
+   * and only enters through the hook's generic signature, so option
+   * objects typed with this interface keep the classic return type.
    * @default 'react'
    */
-  outputFormat?: OutputFormat;
+  outputFormat?: 'react' | 'html';
 
   /**
    * Custom Shiki highlighter instance to use instead of the default one.
@@ -174,7 +178,6 @@ interface TimeoutState {
  * Supported output formats and their corresponding result shapes.
  */
 type OutputFormat = 'react' | 'html' | 'tokens';
-type ComponentOutputFormat = Exclude<OutputFormat, 'tokens'>;
 
 interface HighlightResultMap {
   react: ReactElement;
@@ -190,14 +193,15 @@ type HighlightResult<F extends OutputFormat = 'react'> =
  * Per-call options shape: every highlighter option except `outputFormat`,
  * plus a narrowed `outputFormat?: F` so the return type can be inferred
  * from the format the caller actually passes.
+ *
+ * This is the only place 'tokens' is accepted. Keeping it out of
+ * `HighlighterOptions` means values typed with that interface infer
+ * `F = 'react' | 'html'` and keep their pre-tokens return type.
  */
 type HighlighterOptionsFor<F extends OutputFormat> = Omit<
   HighlighterOptions,
   'outputFormat'
 > & { outputFormat?: F };
-
-type ComponentHighlighterOptions =
-  HighlighterOptionsFor<ComponentOutputFormat>;
 
 type HighlighterFactory = (
   langsToLoad: Language[],
@@ -220,10 +224,8 @@ export type {
   TimeoutState,
   HighlighterOptions,
   HighlighterOptionsFor,
-  ComponentHighlighterOptions,
   HighlightResult,
   HighlightResultMap,
   OutputFormat,
-  ComponentOutputFormat,
   HighlighterFactory,
 };

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -12,6 +12,7 @@ import type {
   SpecialLanguage,
   StringLiteralUnion,
   ThemeRegistrationAny,
+  TokensResult,
 } from 'shiki';
 
 import type { ReactElement } from 'react';
@@ -87,9 +88,10 @@ interface ReactShikiOptions {
    * Output format for the highlighted code.
    * - 'react': Returns React nodes (default, safer)
    * - 'html': Returns HTML string (rendered via dangerouslySetInnerHTML)
+   * - 'tokens': Returns Shiki tokens for custom rendering (hook only)
    * @default 'react'
    */
-  outputFormat?: 'react' | 'html';
+  outputFormat?: OutputFormat;
 
   /**
    * Custom Shiki highlighter instance to use instead of the default one.
@@ -169,9 +171,28 @@ interface TimeoutState {
 }
 
 /**
- * Public API signature for the useShikiHighlighter hook.
+ * Supported output formats and their corresponding result shapes.
  */
-type HighlightedCode = ReactElement | string | null;
+type OutputFormat = 'react' | 'html' | 'tokens';
+type ComponentOutputFormat = Exclude<OutputFormat, 'tokens'>;
+
+interface HighlightResultMap {
+  react: ReactElement;
+  html: string;
+  tokens: TokensResult;
+}
+
+type HighlightResult<F extends OutputFormat = 'react'> =
+  HighlightResultMap[F] | null;
+
+type HighlightedCode = HighlightResult<OutputFormat>;
+type ComponentHighlightedCode = HighlightResult<ComponentOutputFormat>;
+
+type BaseHighlighterOptions = Omit<HighlighterOptions, 'outputFormat'>;
+
+type ComponentHighlighterOptions = BaseHighlighterOptions & {
+  outputFormat?: ComponentOutputFormat;
+};
 
 type HighlighterFactory = (
   langsToLoad: Language[],
@@ -179,12 +200,12 @@ type HighlighterFactory = (
   engine?: Awaitable<RegexEngine>
 ) => Promise<Highlighter | HighlighterCore>;
 
-export type UseShikiHighlighter = (
+export type UseShikiHighlighter = <F extends OutputFormat = 'react'>(
   code: string,
   lang: Language,
   themeInput: Theme | Themes,
-  options?: HighlighterOptions
-) => HighlightedCode;
+  options?: BaseHighlighterOptions & { outputFormat?: F }
+) => HighlightResult<F>;
 
 export type {
   Language,
@@ -193,6 +214,13 @@ export type {
   Element,
   TimeoutState,
   HighlighterOptions,
+  BaseHighlighterOptions,
+  ComponentHighlighterOptions,
+  ComponentHighlightedCode,
   HighlightedCode,
+  HighlightResult,
+  HighlightResultMap,
+  OutputFormat,
+  ComponentOutputFormat,
   HighlighterFactory,
 };

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -183,16 +183,21 @@ interface HighlightResultMap {
 }
 
 type HighlightResult<F extends OutputFormat = 'react'> =
-  HighlightResultMap[F] | null;
+  | HighlightResultMap[F]
+  | null;
 
-type HighlightedCode = HighlightResult<OutputFormat>;
-type ComponentHighlightedCode = HighlightResult<ComponentOutputFormat>;
+/**
+ * Per-call options shape: every highlighter option except `outputFormat`,
+ * plus a narrowed `outputFormat?: F` so the return type can be inferred
+ * from the format the caller actually passes.
+ */
+type HighlighterOptionsFor<F extends OutputFormat> = Omit<
+  HighlighterOptions,
+  'outputFormat'
+> & { outputFormat?: F };
 
-type BaseHighlighterOptions = Omit<HighlighterOptions, 'outputFormat'>;
-
-type ComponentHighlighterOptions = BaseHighlighterOptions & {
-  outputFormat?: ComponentOutputFormat;
-};
+type ComponentHighlighterOptions =
+  HighlighterOptionsFor<ComponentOutputFormat>;
 
 type HighlighterFactory = (
   langsToLoad: Language[],
@@ -204,7 +209,7 @@ export type UseShikiHighlighter = <F extends OutputFormat = 'react'>(
   code: string,
   lang: Language,
   themeInput: Theme | Themes,
-  options?: BaseHighlighterOptions & { outputFormat?: F }
+  options?: HighlighterOptionsFor<F>
 ) => HighlightResult<F>;
 
 export type {
@@ -214,10 +219,8 @@ export type {
   Element,
   TimeoutState,
   HighlighterOptions,
-  BaseHighlighterOptions,
+  HighlighterOptionsFor,
   ComponentHighlighterOptions,
-  ComponentHighlightedCode,
-  HighlightedCode,
   HighlightResult,
   HighlightResultMap,
   OutputFormat,

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -1,4 +1,4 @@
-import { useHighlight } from './lib/hook';
+import { createUseShikiHighlighter } from './lib/hook';
 import { createWebHighlighter } from './bundles/web';
 import type { UseShikiHighlighter } from './lib/types';
 
@@ -50,20 +50,8 @@ export type { LanguageRegistration } from 'shiki/bundle/web';
  *
  * Web bundle (~3.8MB minified, 695KB gzipped). For other bundles: `react-shiki` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter = (
-  code,
-  lang,
-  themeInput,
-  options = {}
-) => {
-  return useHighlight(
-    code,
-    lang,
-    themeInput,
-    options,
-    createWebHighlighter
-  );
-};
+export const useShikiHighlighter: UseShikiHighlighter =
+  createUseShikiHighlighter(createWebHighlighter);
 
 /**
  * ShikiHighlighter component using the web bundle.

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -1,6 +1,13 @@
-import { createUseShikiHighlighter } from './lib/hook';
+import { useHighlight } from './lib/hook';
 import { createWebHighlighter } from './bundles/web';
-import type { UseShikiHighlighter } from './lib/types';
+import type {
+  HighlighterOptionsFor,
+  Language,
+  OutputFormat,
+  Theme,
+  Themes,
+  UseShikiHighlighter,
+} from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -50,8 +57,15 @@ export type { LanguageRegistration } from 'shiki/bundle/web';
  *
  * Web bundle (~3.8MB minified, 695KB gzipped). For other bundles: `react-shiki` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter =
-  createUseShikiHighlighter(createWebHighlighter);
+export const useShikiHighlighter: UseShikiHighlighter = <
+  F extends OutputFormat = 'react',
+>(
+  code: string,
+  lang: Language,
+  themeInput: Theme | Themes,
+  options: HighlighterOptionsFor<F> = {}
+) =>
+  useHighlight<F>(code, lang, themeInput, options, createWebHighlighter);
 
 /**
  * ShikiHighlighter component using the web bundle.

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -25,6 +25,9 @@ export type {
   Themes,
   Element,
   HighlighterOptions,
+  HighlighterOptionsFor,
+  HighlightResult,
+  OutputFormat,
 } from './lib/types';
 
 export {
@@ -32,7 +35,10 @@ export {
   createJavaScriptRawEngine,
 } from 'shiki/engine/javascript';
 
-export type { LanguageRegistration } from 'shiki/bundle/web';
+export type {
+  LanguageRegistration,
+  TokensResult,
+} from 'shiki/bundle/web';
 
 /**
  * Highlight code with shiki (web bundle)
@@ -41,7 +47,7 @@ export type { LanguageRegistration } from 'shiki/bundle/web';
  * @param lang - Language (bundled or custom)
  * @param theme - Theme (bundled, multi-theme, or custom)
  * @param options - react-shiki options + shiki options
- * @returns Highlighted code as React elements or HTML string
+ * @returns Highlighted code as React elements (default), HTML string, or Shiki tokens, based on `outputFormat`
  *
  * @example
  * ```tsx

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -1,13 +1,6 @@
 import { useHighlight } from './lib/hook';
 import { createWebHighlighter } from './bundles/web';
-import type {
-  HighlighterOptionsFor,
-  Language,
-  OutputFormat,
-  Theme,
-  Themes,
-  UseShikiHighlighter,
-} from './lib/types';
+import type { UseShikiHighlighter } from './lib/types';
 
 export { isInlineCode, rehypeInlineCodeProperty } from './lib/plugins';
 
@@ -63,15 +56,12 @@ export type {
  *
  * Web bundle (~3.8MB minified, 695KB gzipped). For other bundles: `react-shiki` or `react-shiki/core`
  */
-export const useShikiHighlighter: UseShikiHighlighter = <
-  F extends OutputFormat = 'react',
->(
-  code: string,
-  lang: Language,
-  themeInput: Theme | Themes,
-  options: HighlighterOptionsFor<F> = {}
-) =>
-  useHighlight<F>(code, lang, themeInput, options, createWebHighlighter);
+export const useShikiHighlighter: UseShikiHighlighter = (
+  code,
+  lang,
+  themeInput,
+  options = {}
+) => useHighlight(code, lang, themeInput, options, createWebHighlighter);
 
 /**
  * ShikiHighlighter component using the web bundle.

--- a/package/tests/component.test.tsx
+++ b/package/tests/component.test.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import {
   ShikiHighlighter,
@@ -244,6 +245,38 @@ describe('ShikiHighlighter Component', () => {
         expect(container.querySelector('pre')).toBeInTheDocument();
         expect(container.querySelector('code')).toBeInTheDocument();
       });
+    });
+
+    test('warns and falls back to react output when outputFormat is tokens', async () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const { container } = render(
+        <ShikiHighlighter
+          language="javascript"
+          theme="github-dark"
+          // Types forbid 'tokens' on the component; plain-JS callers can still pass it
+          outputFormat={'tokens' as never}
+        >
+          {codeSample}
+        </ShikiHighlighter>
+      );
+
+      await waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("outputFormat 'tokens'")
+        );
+
+        // Falls back to React element output instead of crashing
+        const shikiContainer = getContainer(container);
+        expect(
+          shikiContainer?.querySelector('pre.shiki')
+        ).toBeInTheDocument();
+        expect(shikiContainer?.querySelector('code')).toBeInTheDocument();
+      });
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '../src/index';
 import { useShikiHighlighter as useShikiHighlighterCore } from '../src/core';
 import type {
-  ComponentOutputFormat,
   HighlightResult,
   Language,
   Theme,
@@ -25,7 +24,7 @@ interface TestComponentProps {
   showLineNumbers?: boolean;
   startingLineNumber?: number;
   highlightLineNumbers?: number[];
-  outputFormat?: ComponentOutputFormat;
+  outputFormat?: 'react' | 'html';
   defaultColor?: string;
   cssVariablePrefix?: string;
   mergeWhitespaces?: boolean;
@@ -908,7 +907,7 @@ describe('useShikiHighlighter Hook', () => {
             ]),
           ],
         });
-        expect(capturedOutput!.tokens[0].length).toBeGreaterThan(1);
+        expect(capturedOutput?.tokens[0]?.length).toBeGreaterThan(1);
       });
     });
   });

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -5,7 +5,12 @@ import {
   createJavaScriptRegexEngine,
 } from '../src/index';
 import { useShikiHighlighter as useShikiHighlighterCore } from '../src/core';
-import type { Language, Theme, Themes } from '../src/lib/types';
+import type {
+  HighlightResult,
+  Language,
+  Theme,
+  Themes,
+} from '../src/lib/types';
 import type { ShikiTransformer, Highlighter, LanguageInput } from 'shiki';
 import { throttleHighlighting } from '../src/lib/utils';
 import { useHighlight as useBaseHook } from '../src/lib/hook';
@@ -62,6 +67,9 @@ describe('useShikiHighlighter Hook', () => {
       getLoadedLanguages: vi.fn(() => ['markdown']),
       codeToHtml: vi.fn(() => '<pre class="shiki"><code>ok</code></pre>'),
       codeToHast: vi.fn(() => ({ type: 'root', children: [] })),
+      codeToTokens: vi.fn(() => ({
+        tokens: [[{ content: 'ok', offset: 0 }]],
+      })),
     } as unknown as Highlighter;
 
     return highlighter;
@@ -868,6 +876,38 @@ describe('useShikiHighlighter Hook', () => {
 
         // Verify the code content is preserved
         expect(container.textContent).toContain('const x = 1;');
+      });
+    });
+
+    test('returns Shiki tokens when outputFormat is tokens', async () => {
+      let capturedOutput: HighlightResult<'tokens'> = null;
+
+      const TestCapture = () => {
+        const highlighted = useShikiHighlighter(
+          'const x = 1;',
+          'javascript',
+          'github-dark',
+          { outputFormat: 'tokens' }
+        );
+        capturedOutput = highlighted;
+
+        return <div data-testid="output">ready</div>;
+      };
+
+      render(<TestCapture />);
+
+      await waitFor(() => {
+        expect(capturedOutput).toMatchObject({
+          tokens: [
+            expect.arrayContaining([
+              expect.objectContaining({
+                content: 'const',
+                offset: 0,
+              }),
+            ]),
+          ],
+        });
+        expect(capturedOutput!.tokens[0].length).toBeGreaterThan(1);
       });
     });
   });

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -6,6 +6,7 @@ import {
 } from '../src/index';
 import { useShikiHighlighter as useShikiHighlighterCore } from '../src/core';
 import type {
+  ComponentOutputFormat,
   HighlightResult,
   Language,
   Theme,
@@ -24,7 +25,7 @@ interface TestComponentProps {
   showLineNumbers?: boolean;
   startingLineNumber?: number;
   highlightLineNumbers?: number[];
-  outputFormat?: 'react' | 'html';
+  outputFormat?: ComponentOutputFormat;
   defaultColor?: string;
   cssVariablePrefix?: string;
   mergeWhitespaces?: boolean;

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -910,6 +910,21 @@ describe('useShikiHighlighter Hook', () => {
         expect(capturedOutput?.tokens[0]?.length).toBeGreaterThan(1);
       });
     });
+
+    test('falls back to react rendering for unrecognized outputFormat', async () => {
+      const { getByTestId } = renderComponent({
+        code: 'const x = 1;',
+        language: 'javascript',
+        outputFormat: 'token' as any,
+      });
+
+      await waitFor(() => {
+        const container = getByTestId('highlighted');
+        expect(
+          container.querySelector('pre.shiki code span.line')
+        ).toBeInTheDocument();
+      });
+    });
   });
 
   describe('Engine Configuration', () => {

--- a/package/tests/types.test-d.tsx
+++ b/package/tests/types.test-d.tsx
@@ -1,0 +1,86 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { ReactElement } from 'react';
+
+import {
+  ShikiHighlighter,
+  useShikiHighlighter,
+  type HighlighterOptions,
+  type TokensResult,
+} from '../src/index';
+
+const code = 'const x = 1;';
+
+/**
+ * The tokens format is deliberately excluded from HighlighterOptions and
+ * only enters through the hook's generic signature. These tests pin that
+ * design: literal outputFormat values narrow the hook's return type, while
+ * HighlighterOptions-typed option objects (wrappers forwarding options)
+ * keep the pre-tokens return union with no TokensResult in it.
+ */
+describe('useShikiHighlighter return type', () => {
+  test('defaults to ReactElement', () => {
+    expectTypeOf(
+      useShikiHighlighter(code, 'ts', 'github-dark')
+    ).toEqualTypeOf<ReactElement | null>();
+  });
+
+  test("literal 'react' returns ReactElement", () => {
+    expectTypeOf(
+      useShikiHighlighter(code, 'ts', 'github-dark', {
+        outputFormat: 'react',
+      })
+    ).toEqualTypeOf<ReactElement | null>();
+  });
+
+  test("literal 'html' returns string", () => {
+    expectTypeOf(
+      useShikiHighlighter(code, 'ts', 'github-dark', {
+        outputFormat: 'html',
+      })
+    ).toEqualTypeOf<string | null>();
+  });
+
+  test("literal 'tokens' returns TokensResult", () => {
+    expectTypeOf(
+      useShikiHighlighter(code, 'ts', 'github-dark', {
+        outputFormat: 'tokens',
+      })
+    ).toEqualTypeOf<TokensResult | null>();
+  });
+
+  test('HighlighterOptions-typed options keep the pre-tokens union', () => {
+    const options: HighlighterOptions = {};
+    expectTypeOf(
+      useShikiHighlighter(code, 'ts', 'github-dark', options)
+    ).toEqualTypeOf<ReactElement | string | null>();
+  });
+});
+
+describe('ShikiHighlighter outputFormat prop', () => {
+  test("accepts 'react' and 'html', rejects 'tokens'", () => {
+    <ShikiHighlighter
+      language="ts"
+      theme="github-dark"
+      outputFormat="react"
+    >
+      {code}
+    </ShikiHighlighter>;
+
+    <ShikiHighlighter
+      language="ts"
+      theme="github-dark"
+      outputFormat="html"
+    >
+      {code}
+    </ShikiHighlighter>;
+
+    <ShikiHighlighter
+      language="ts"
+      theme="github-dark"
+      // @ts-expect-error tokens output is hook-only
+      outputFormat="tokens"
+    >
+      {code}
+    </ShikiHighlighter>;
+  });
+});

--- a/package/tsconfig.vitest.json
+++ b/package/tsconfig.vitest.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tests/**/*.test-d.tsx"]
+}

--- a/package/vitest.config.ts
+++ b/package/vitest.config.ts
@@ -12,5 +12,10 @@ export default defineConfig({
     setupFiles: './tests/setup.ts',
     include: ['tests/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['tests/**/*.bench.{ts,tsx}'],
+    typecheck: {
+      enabled: true,
+      include: ['tests/**/*.test-d.{ts,tsx}'],
+      tsconfig: './tsconfig.vitest.json',
+    },
   },
 });


### PR DESCRIPTION
## Summary

Adds experimental `outputFormat: 'tokens'` support to `useShikiHighlighter`, returning Shiki's raw `TokensResult` for consumers who want to own rendering themselves (custom renderers, virtualization, etc.).

Token output is **hook-only by design**: the `ShikiHighlighter` component's value (default styles, line numbers, the HTML fast path) assumes react-shiki's generated markup, which no longer exists once the caller controls rendering. A component-level renderer slot may be explored separately if there's demand.

## Design

- **Return type narrowing**: the hook's return type is inferred from the literal `outputFormat` passed. `'react'` returns `ReactElement`, `'html'` returns `string`, `'tokens'` returns `TokensResult` (all `| null` while highlighting is pending).
- **No breakage for existing callers**: the public `HighlighterOptions` interface keeps `outputFormat?: 'react' | 'html'`, unchanged from the previous release. The `'tokens'` literal is accepted only through the hook's generic parameter (`HighlighterOptionsFor<F>`). Wrappers that forward a `HighlighterOptions`-typed object therefore infer `F = 'react' | 'html'` and keep the pre-tokens return type; `TokensResult` never enters their union. Verified with tsc probes against the wrapper-forwarding and `ReactNode`-assignment patterns.
- **Component exclusion comes free**: since `HighlighterOptions` never includes `'tokens'`, the component extends it directly and no dedicated `ComponentOutputFormat` / `ComponentHighlighterOptions` types are needed.
- **Runtime guard**: plain-JS callers can bypass the types, and a `TokensResult` object would crash React's render with "Objects are not valid as a React child". The component warns once (`console.warn`, matching the existing `theme.ts` convention) and falls back to `'react'`.

## Docs

- README documents the tokens format with a custom-render example, marked experimental.
- Notes that transformers and decorations run in the HAST pipeline that token output bypasses, so they have no effect on `'tokens'`.

## Release notes

Changeset is `patch`: the feature is experimental and no public types change shape for existing callers.

## Verification

- `vitest` 92/92 (new tests: hook returns `TokensResult`; component warns and falls back)
- tsc probes confirm literal-caller narrowing and unchanged inference for `HighlighterOptions`-typed forwarding
- `tsc --noEmit`, `biome check` clean on touched files
- `tsdown` build with attw and publint clean
