### PR TITLE
fix: scope all CSS and remove deprecated line number classes

### DIFF
--- a/.changeset/scope-css-remove-legacy.md
+++ b/.changeset/scope-css-remove-legacy.md
@@ -1,0 +1,21 @@
+---
+"react-shiki": patch
+---
+
+Scope CSS to react-shiki's own DOM and drop deprecated unprefixed aliases (closes #162).
+
+**Breaking:** unprefixed classes and CSS variables are removed. Substitute as follows:
+
+| Removed                          | Replacement                          |
+| -------------------------------- | ------------------------------------ |
+| `.line-numbers`                  | `.rs-line-number`                    |
+| `.has-line-numbers`              | `.rs-has-line-numbers`               |
+| `--line-numbers-foreground`      | `--rs-line-numbers-foreground`       |
+| `--line-numbers-width`           | `--rs-line-numbers-width`            |
+| `--line-numbers-padding-left`    | `--rs-line-numbers-padding-left`     |
+| `--line-numbers-padding-right`   | `--rs-line-numbers-padding-right`    |
+| `--line-numbers-font-size`       | `--rs-line-numbers-font-size`        |
+| `--line-numbers-font-weight`     | `--rs-line-numbers-font-weight`      |
+| `--line-numbers-line-height`     | `--rs-line-numbers-line-height`      |
+| `--line-numbers-font-family`     | `--rs-line-numbers-font-family`      |
+| `--line-numbers-opacity`         | `--rs-line-numbers-opacity`          |

--- a/package/README.md
+++ b/package/README.md
@@ -468,7 +468,7 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 > ```
 
 > [!WARNING]
-> Legacy `.line-numbers` / `.has-line-numbers` selectors and unprefixed line-number CSS variables are still supported for this release cycle, but are deprecated and will be removed in the next major.
+> Legacy `.line-numbers` / `.has-line-numbers` selectors and unprefixed line-number CSS variables are removed as of 0.10.1.
 
 Component-internal default classes are namespaced under `rs-*` and shipped inside `@layer base` so app-level utilities can override them more predictably.
 

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -8,7 +8,6 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
   return {
     name: 'react-shiki:line-numbers',
     code(node) {
-      this.addClassToHast(node, 'has-line-numbers');
       this.addClassToHast(node, 'rs-has-line-numbers');
       if (startLine !== 1) {
         const existingStyle = (node.properties?.style as string) || '';
@@ -22,7 +21,6 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
       }
     },
     line(node) {
-      this.addClassToHast(node, 'line-numbers');
       this.addClassToHast(node, 'rs-line-number');
       return node;
     },

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -1,24 +1,24 @@
 @layer base {
   .rs-root {
     position: relative;
-  }
 
-  .rs-default-styles pre {
-    overflow: auto;
-    border-radius: 0.5rem;
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-    padding-top: 1.25rem;
-    padding-bottom: 1.25rem;
-  }
+    &.rs-default-styles pre {
+      overflow: auto;
+      border-radius: 0.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      padding-top: 1.25rem;
+      padding-bottom: 1.25rem;
+    }
 
-  .rs-language-label {
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
-    font-family: monospace;
-    font-size: 0.75rem;
-    letter-spacing: -0.05em;
-    color: rgba(107, 114, 128, 0.85);
+    & .rs-language-label {
+      position: absolute;
+      right: 0.75rem;
+      top: 0.5rem;
+      font-family: monospace;
+      font-size: 0.75rem;
+      letter-spacing: -0.05em;
+      color: rgba(107, 114, 128, 0.85);
+    }
   }
 }

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -1,49 +1,25 @@
 @layer base {
-  .rs-line-number::before {
-    counter-increment: line-number;
-    content: counter(line-number);
-    display: inline-flex;
-    justify-content: flex-end;
-    align-items: flex-start;
-    box-sizing: content-box;
-    min-width: var(--rs-line-numbers-width, 2ch);
-    padding-left: var(--rs-line-numbers-padding-left, 2ch);
-    padding-right: var(--rs-line-numbers-padding-right, 2ch);
-    color: var(--rs-line-numbers-foreground, rgba(107, 114, 128, 0.6));
-    font-size: var(--rs-line-numbers-font-size, inherit);
-    font-weight: var(--rs-line-numbers-font-weight, inherit);
-    line-height: var(--rs-line-numbers-line-height, inherit);
-    font-family: var(--rs-line-numbers-font-family, inherit);
-    opacity: var(--rs-line-numbers-opacity, 1);
-    user-select: none;
-    pointer-events: none;
-  }
-
   .rs-has-line-numbers {
     counter-reset: line-number calc(var(--line-start, 1) - 1);
-    --rs-line-numbers-foreground: var(
-      --line-numbers-foreground,
-      rgba(107, 114, 128, 0.5)
-    );
-    --rs-line-numbers-width: var(--line-numbers-width, 2ch);
-    --rs-line-numbers-padding-left: var(--line-numbers-padding-left, 0ch);
-    --rs-line-numbers-padding-right: var(
-      --line-numbers-padding-right,
-      2ch
-    );
-    --rs-line-numbers-font-size: var(--line-numbers-font-size, inherit);
-    --rs-line-numbers-font-weight: var(
-      --line-numbers-font-weight,
-      inherit
-    );
-    --rs-line-numbers-line-height: var(
-      --line-numbers-line-height,
-      inherit
-    );
-    --rs-line-numbers-font-family: var(
-      --line-numbers-font-family,
-      inherit
-    );
-    --rs-line-numbers-opacity: var(--line-numbers-opacity, 1);
+
+    & .rs-line-number::before {
+      counter-increment: line-number;
+      content: counter(line-number);
+      display: inline-flex;
+      justify-content: flex-end;
+      align-items: flex-start;
+      box-sizing: content-box;
+      min-width: var(--rs-line-numbers-width, 2ch);
+      padding-left: var(--rs-line-numbers-padding-left, 0ch);
+      padding-right: var(--rs-line-numbers-padding-right, 2ch);
+      color: var(--rs-line-numbers-foreground, rgba(107, 114, 128, 0.5));
+      font-size: var(--rs-line-numbers-font-size, inherit);
+      font-weight: var(--rs-line-numbers-font-weight, inherit);
+      line-height: var(--rs-line-numbers-line-height, inherit);
+      font-family: var(--rs-line-numbers-font-family, inherit);
+      opacity: var(--rs-line-numbers-opacity, 1);
+      user-select: none;
+      pointer-events: none;
+    }
   }
 }

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -1,5 +1,4 @@
 @layer base {
-  .line-numbers::before,
   .rs-line-number::before {
     counter-increment: line-number;
     content: counter(line-number);
@@ -20,7 +19,6 @@
     pointer-events: none;
   }
 
-  .has-line-numbers,
   .rs-has-line-numbers {
     counter-reset: line-number calc(var(--line-start, 1) - 1);
     --rs-line-numbers-foreground: var(

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -479,11 +479,7 @@ describe('useShikiHighlighter Hook', () => {
       await waitFor(() => {
         const container = getByTestId('highlighted');
         const codeElement = container.querySelector('code');
-        expect(codeElement).not.toHaveClass('has-line-numbers');
         expect(codeElement).not.toHaveClass('rs-has-line-numbers');
-
-        const lineElements = container.querySelectorAll('.line-numbers');
-        expect(lineElements).toHaveLength(0);
 
         const rsLineElements =
           container.querySelectorAll('.rs-line-number');
@@ -501,15 +497,11 @@ describe('useShikiHighlighter Hook', () => {
       await waitFor(() => {
         const container = getByTestId('highlighted');
         const codeElement = container.querySelector('code');
-        expect(codeElement).toHaveClass('has-line-numbers');
         expect(codeElement).toHaveClass('rs-has-line-numbers');
-
-        const lineElements = container.querySelectorAll('.line-numbers');
-        expect(lineElements.length).toBeGreaterThan(0);
 
         const rsLineElements =
           container.querySelectorAll('.rs-line-number');
-        expect(rsLineElements.length).toBe(lineElements.length);
+        expect(rsLineElements.length).toBeGreaterThan(0);
       });
     });
 


### PR DESCRIPTION
## Summary

Closes #162. Removes deprecated classes and scopes line-number CSS under `.rs-has-line-numbers` and component CSS under `.rs-root` so styles only apply to react-shiki's own output.

## Breaking changes

Unprefixed classes and CSS variables are removed. Substitute as follows:

| Removed                          | Replacement                          |
| -------------------------------- | ------------------------------------ |
| `.line-numbers`                  | `.rs-line-number`                    |
| `.has-line-numbers`              | `.rs-has-line-numbers`               |
| `--line-numbers-foreground`      | `--rs-line-numbers-foreground`       |
| `--line-numbers-width`           | `--rs-line-numbers-width`            |
| `--line-numbers-padding-left`    | `--rs-line-numbers-padding-left`     |
| `--line-numbers-padding-right`   | `--rs-line-numbers-padding-right`    |
| `--line-numbers-font-size`       | `--rs-line-numbers-font-size`        |
| `--line-numbers-font-weight`     | `--rs-line-numbers-font-weight`      |
| `--line-numbers-line-height`     | `--rs-line-numbers-line-height`      |
| `--line-numbers-font-family`     | `--rs-line-numbers-font-family`      |
| `--line-numbers-opacity`         | `--rs-line-numbers-opacity`          |
