### PR TITLE
ci: update claude-code-action to v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,15 +33,20 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Optional: Specify model via CLI args (defaults to the action's current model)
+          # claude_args: --model claude-opus-4-5-20251101
+
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request.
+
             Important, ensure:
             - PR includes changeset when updating package source
             - PR includes documentation updates when API surface changes
@@ -65,15 +70,15 @@ jobs:
           use_sticky_comment: true
           
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          # claude_args: --allowedTools "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
           
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: pin a model via CLI args ("opus" always resolves to the latest Opus)
-          # claude_args: --model opus
+          # "opus" is a Claude Code alias that always resolves to the latest Opus model
+          claude_args: --model opus
 
           # Prompt for automated review (no @claude mention needed)
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model via CLI args (defaults to the action's current model)
-          # claude_args: --model claude-opus-4-5-20251101
+          # Optional: pin a model via CLI args ("opus" always resolves to the latest Opus)
+          # claude_args: --model opus
 
           # Prompt for automated review (no @claude mention needed)
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,17 +32,17 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-5-20251101"
-          
+
+          # Optional: Specify model via CLI args (defaults to the action's current model)
+          claude_args: --model claude-opus-4-5-20251101
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           
@@ -50,15 +50,12 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+          # claude_args: --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
+          # claude_args: --system-prompt "Follow our coding standards. Ensure all new code has tests."
+
           # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # settings: |
+          #   { "env": { "NODE_ENV": "test" } }
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model via CLI args (defaults to the action's current model)
-          claude_args: --model claude-opus-4-5-20251101
+          # "opus" is a Claude Code alias that always resolves to the latest Opus model
+          claude_args: --model opus
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
the automated pr review stopped working because `claude-code-action@beta` is a stale tag that defaults to a retired model (`claude-sonnet-4-20250514`), so every run 404'd at the api call.

this migrates both workflows to `@v1` and its new input syntax (`direct_prompt` -> `prompt`, `model` -> `claude_args: --model`), and swaps the hardcoded model pin for the `opus` alias so reviews always track the latest opus without future retirement breakage. commented-out config examples updated to v1 syntax too.