### PR TITLE
feat: add highlighted line support

### DIFF
--- a/.changeset/highlight-line-numbers.md
+++ b/.changeset/highlight-line-numbers.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": minor
+---
+
+feat: add `highlightLineNumbers` option to highlight specific lines by displayed line number (respects `startingLineNumber`). Highlighted lines get the `rs-highlighted-line` class; the default background is customizable via `--rs-highlighted-line-background`.

--- a/.changeset/highlight-line-numbers.md
+++ b/.changeset/highlight-line-numbers.md
@@ -2,4 +2,4 @@
 "react-shiki": minor
 ---
 
-feat: add `highlightLineNumbers` option to highlight specific lines by displayed line number (respects `startingLineNumber`). Highlighted lines get the `rs-highlighted-line` class; the default background is customizable via `--rs-highlighted-line-background`.
+feat: add `highlightLineNumbers` option to highlight specific lines by displayed line number (respects `startingLineNumber`). Highlighted lines get the `rs-highlighted-line` class; defaults are theme-adaptive and customizable via `--rs-highlighted-line-background` and `--rs-highlighted-line-number-foreground`.

--- a/package/README.md
+++ b/package/README.md
@@ -452,7 +452,7 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 
 > [!NOTE]
 > When using the hook with line numbers or highlighted lines, import the CSS file or provide your own CSS
-> for `.rs-line-number` (line `span`), `.rs-highlighted-line` (line `span`), and `.rs-has-line-numbers` (container `code` element).
+> for `.rs-line-number` (line `span`), `.rs-highlighted-line` (line `span`), and `.rs-has-line-numbers` / `.rs-has-highlighted-lines` (container `code` element).
 > ```tsx
 > import 'react-shiki/css';
 > ```
@@ -471,6 +471,7 @@ Available CSS variables for customization:
 --rs-line-numbers-font-weight: inherit;
 --rs-line-numbers-opacity: 1;
 --rs-highlighted-line-background: color-mix(in srgb, currentColor 10%, transparent);
+--rs-highlighted-line-number-foreground: color-mix(in srgb, currentColor 65%, transparent);
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:

--- a/package/README.md
+++ b/package/README.md
@@ -218,7 +218,7 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `engine`            | `RegexEngine`      | Oniguruma       | RegExp engine for syntax highlighting (Oniguruma, JavaScript RegExp, or JavaScript Raw) |
 | `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
 | `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
-| `highlightLineNumbers` | `number[]`     | `[]`            | Displayed line numbers to highlight                                           |
+| `highlightLineNumbers` | `number[]`     | -               | Displayed line numbers to highlight                                           |
 | `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
 | `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
 | `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |

--- a/package/README.md
+++ b/package/README.md
@@ -218,6 +218,7 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `engine`            | `RegexEngine`      | Oniguruma       | RegExp engine for syntax highlighting (Oniguruma, JavaScript RegExp, or JavaScript Raw) |
 | `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
 | `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
+| `highlightLineNumbers` | `number[]`     | `[]`            | Displayed line numbers to highlight                                           |
 | `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
 | `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
 | `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |
@@ -436,6 +437,7 @@ Line numbers are CSS-based and can be customized with CSS variables:
   theme="github-dark"
   showLineNumbers
   startingLineNumber={0} // default is 1
+  highlightLineNumbers={[2, 4]}
 >
   {code}
 </ShikiHighlighter>
@@ -443,16 +445,19 @@ Line numbers are CSS-based and can be customized with CSS variables:
 // Hook (import 'react-shiki/css' for line numbers to work)
 const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
   showLineNumbers: true,
-  startingLineNumber: 0, 
+  startingLineNumber: 0,
+  highlightLineNumbers: [2, 4],
 });
 ```
 
 > [!NOTE]
-> When using the hook with line numbers, import the CSS file or provide your own CSS 
-> for `.rs-line-number` (line `span`) and `.rs-has-line-numbers` (container `code` element).
+> When using the hook with line numbers or highlighted lines, import the CSS file or provide your own CSS
+> for `.rs-line-number` (line `span`), `.rs-highlighted-line` (line `span`), and `.rs-has-line-numbers` (container `code` element).
 > ```tsx
 > import 'react-shiki/css';
 > ```
+
+`highlightLineNumbers` uses displayed line numbers, so it works with `startingLineNumber`.
 
 Component-internal default classes are namespaced under `rs-*` and written with zero-specificity `:where()` selectors, so they can't be clobbered by CSS resets (e.g. Tailwind preflight) regardless of stylesheet load order, while any rule in your own CSS — even a bare element selector — overrides them.
 
@@ -465,6 +470,7 @@ Available CSS variables for customization:
 --rs-line-numbers-font-size: inherit;
 --rs-line-numbers-font-weight: inherit;
 --rs-line-numbers-opacity: 1;
+--rs-highlighted-line-background: rgba(250, 204, 21, 0.18);
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:

--- a/package/README.md
+++ b/package/README.md
@@ -470,7 +470,7 @@ Available CSS variables for customization:
 --rs-line-numbers-font-size: inherit;
 --rs-line-numbers-font-weight: inherit;
 --rs-line-numbers-opacity: 1;
---rs-highlighted-line-background: rgba(250, 204, 21, 0.18);
+--rs-highlighted-line-background: color-mix(in srgb, currentColor 10%, transparent);
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -87,6 +87,12 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
   startingLineNumber?: number;
 
   /**
+   * Displayed line numbers to highlight
+   * @default []
+   */
+  highlightLineNumbers?: number[];
+
+  /**
    * The HTML element that wraps the generated code block.
    * @default 'div'
    */
@@ -117,6 +123,7 @@ export const createShikiHighlighterComponent = (
         showLanguage = true,
         showLineNumbers = false,
         startingLineNumber = 1,
+        highlightLineNumbers,
         children: code,
         as: Element = 'div',
         customLanguages,
@@ -135,6 +142,7 @@ export const createShikiHighlighterComponent = (
         defaultColor,
         cssVariablePrefix,
         startingLineNumber,
+        highlightLineNumbers,
         ...shikiOptions,
       };
 

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -88,7 +88,6 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
 
   /**
    * Displayed line numbers to highlight
-   * @default []
    */
   highlightLineNumbers?: number[];
 

--- a/package/src/lib/options.ts
+++ b/package/src/lib/options.ts
@@ -7,7 +7,10 @@ import type {
 
 import type { HighlighterOptions } from './types';
 import type { ResolvedTheme } from './theme';
-import { lineNumbersTransformer } from './transformers';
+import {
+  highlightedLinesTransformer,
+  lineNumbersTransformer,
+} from './transformers';
 
 const buildThemeOptions = (
   resolvedTheme: ResolvedTheme,
@@ -46,6 +49,7 @@ export const buildShikiOptions = (
     cssVariablePrefix,
     showLineNumbers,
     startingLineNumber,
+    highlightLineNumbers,
     transformers: userTransformers,
     ...shikiPassthrough
   } = options;
@@ -53,6 +57,14 @@ export const buildShikiOptions = (
   const transformers = [...(userTransformers || [])];
   if (showLineNumbers) {
     transformers.push(lineNumbersTransformer(startingLineNumber));
+  }
+  if (highlightLineNumbers?.length) {
+    transformers.push(
+      highlightedLinesTransformer(
+        highlightLineNumbers,
+        startingLineNumber
+      )
+    );
   }
 
   return {

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -1,5 +1,8 @@
 import type { ShikiTransformer } from 'shiki/core';
 
+const toLineNumberSet = (lineNumbers: readonly number[]) =>
+  new Set(lineNumbers.filter(Number.isInteger));
+
 /**
  * Creates a transformer that enables line numbers display
  * @param startLine - The starting line number (defaults to 1)
@@ -22,6 +25,31 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
     },
     line(node) {
       this.addClassToHast(node, 'rs-line-number');
+      return node;
+    },
+  };
+}
+
+/**
+ * Creates a transformer that marks selected displayed line numbers.
+ * @param lineNumbers - Displayed line numbers to highlight
+ * @param startLine - The starting line number (defaults to 1)
+ */
+export function highlightedLinesTransformer(
+  lineNumbers: readonly number[],
+  startLine = 1
+): ShikiTransformer {
+  const highlightedLines = toLineNumberSet(lineNumbers);
+
+  return {
+    name: 'react-shiki:highlight-lines',
+    line(node, line) {
+      const displayedLine = startLine + line - 1;
+
+      if (highlightedLines.has(displayedLine)) {
+        this.addClassToHast(node, 'rs-highlighted-line');
+      }
+
       return node;
     },
   };

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -43,6 +43,9 @@ export function highlightedLinesTransformer(
 
   return {
     name: 'react-shiki:highlight-lines',
+    code(node) {
+      this.addClassToHast(node, 'rs-has-highlighted-lines');
+    },
     line(node, line) {
       const displayedLine = startLine + line - 1;
 

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -134,7 +134,6 @@ interface ReactShikiOptions {
 
   /**
    * Displayed line numbers to highlight
-   * @default []
    */
   highlightLineNumbers?: number[];
 }

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -131,6 +131,12 @@ interface ReactShikiOptions {
    * @default 1
    */
   startingLineNumber?: number;
+
+  /**
+   * Displayed line numbers to highlight
+   * @default []
+   */
+  highlightLineNumbers?: number[];
 }
 
 /**

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -27,6 +27,6 @@
   width: 100%;
   background-color: var(
     --rs-highlighted-line-background,
-    rgba(250, 204, 21, 0.18)
+    color-mix(in srgb, currentColor 10%, transparent)
   );
 }

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -33,6 +33,7 @@
 :where(.rs-highlighted-line) {
   display: inline-block;
   width: 100%;
+  min-height: 1lh;
   background-color: var(
     --rs-highlighted-line-background,
     color-mix(in srgb, currentColor 10%, transparent)

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -21,3 +21,12 @@
   user-select: none;
   pointer-events: none;
 }
+
+:where(.rs-highlighted-line) {
+  display: inline-block;
+  width: 100%;
+  background-color: var(
+    --rs-highlighted-line-background,
+    rgba(250, 204, 21, 0.18)
+  );
+}

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -22,11 +22,26 @@
   pointer-events: none;
 }
 
+/* Size the code element to its content so line backgrounds
+   span the full scroll width, not just the visible area. */
+:where(.rs-has-highlighted-lines) {
+  display: block;
+  width: fit-content;
+  min-width: 100%;
+}
+
 :where(.rs-highlighted-line) {
   display: inline-block;
   width: 100%;
   background-color: var(
     --rs-highlighted-line-background,
     color-mix(in srgb, currentColor 10%, transparent)
+  );
+}
+
+:where(.rs-has-line-numbers .rs-highlighted-line)::before {
+  color: var(
+    --rs-highlighted-line-number-foreground,
+    color-mix(in srgb, currentColor 65%, transparent)
   );
 }

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -18,6 +18,7 @@ interface TestComponentProps {
   langAlias?: Record<string, string>;
   showLineNumbers?: boolean;
   startingLineNumber?: number;
+  highlightLineNumbers?: number[];
   outputFormat?: 'react' | 'html';
   defaultColor?: string;
   cssVariablePrefix?: string;
@@ -386,7 +387,9 @@ describe('useShikiHighlighter Hook', () => {
 
     test('tolerates a fresh factory arrow on every render', async () => {
       const highlighter = createMockHighlighter();
-      const codeToHtml = highlighter.codeToHtml as ReturnType<typeof vi.fn>;
+      const codeToHtml = highlighter.codeToHtml as ReturnType<
+        typeof vi.fn
+      >;
 
       const UnstableFactoryHarness = ({ tick }: { tick: number }) => {
         // tick forces a parent re-render but does not change anything the
@@ -434,7 +437,9 @@ describe('useShikiHighlighter Hook', () => {
       // `highlighterFactory` arrow each render. With the bug present,
       // codeToHtml is invoked more than once as the effect re-fires.
       const highlighter = createMockHighlighter();
-      const codeToHtml = highlighter.codeToHtml as ReturnType<typeof vi.fn>;
+      const codeToHtml = highlighter.codeToHtml as ReturnType<
+        typeof vi.fn
+      >;
 
       const CoreHarness = () => {
         const highlighted = useShikiHighlighterCore(
@@ -539,6 +544,27 @@ describe('useShikiHighlighter Hook', () => {
           '[style*="--line-start"]'
         );
         expect(elementsWithStyle.length).toBe(0);
+      });
+    });
+
+    test('highlights displayed line numbers', async () => {
+      const { getByTestId } = renderComponent({
+        code,
+        language: 'javascript',
+        startingLineNumber: 41,
+        highlightLineNumbers: [42],
+      });
+
+      await waitFor(() => {
+        const container = getByTestId('highlighted');
+        const highlightedLines = container.querySelectorAll(
+          '.rs-highlighted-line'
+        );
+
+        expect(highlightedLines).toHaveLength(1);
+        expect(highlightedLines[0]?.textContent).toContain(
+          "return 'hello';"
+        );
       });
     });
   });

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -565,6 +565,9 @@ describe('useShikiHighlighter Hook', () => {
         expect(highlightedLines[0]?.textContent).toContain(
           "return 'hello';"
         );
+        expect(
+          container.querySelector('code.rs-has-highlighted-lines')
+        ).not.toBeNull();
       });
     });
   });

--- a/package/tests/options.test.ts
+++ b/package/tests/options.test.ts
@@ -90,4 +90,20 @@ describe('buildShikiOptions', () => {
       name: 'react-shiki:line-numbers',
     });
   });
+
+  test('adds highlighted line transformer with starting line number', () => {
+    const options = buildShikiOptions(
+      'typescript',
+      resolveTheme('github-dark'),
+      {
+        highlightLineNumbers: [10],
+        startingLineNumber: 10,
+      }
+    );
+
+    expect(options.transformers).toHaveLength(1);
+    expect(options.transformers?.[0]).toMatchObject({
+      name: 'react-shiki:highlight-lines',
+    });
+  });
 });

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -214,6 +214,32 @@ console.log(result); // 55
 `.trim()}
 </ShikiHighlighter>
 
+### Highlighted Lines
+[View docs →](https://github.com/avgvstvs96/react-shiki#line-numbers)
+
+<ShikiHighlighter language="javascript" theme="material-theme-ocean" showLineNumbers highlightLineNumbers={[2, 3, 7]}>
+{`
+function fibonacci(n) {
+    if (n <= 1) return n;
+    return fibonacci(n - 1) + fibonacci(n - 2); // this is a deliberately long highlighted line to test how the highlight background behaves when the code block scrolls horizontally past the visible area
+}
+
+// Example usage
+const result = fibonacci(10);
+console.log(result); // 55
+`.trim()}
+</ShikiHighlighter>
+
+Without line numbers:
+
+<ShikiHighlighter language="javascript" theme="material-theme-ocean" highlightLineNumbers={[2]}>
+{`
+function greet(name) {
+    return \`Hello, \${name}!\`;
+}
+`.trim()}
+</ShikiHighlighter>
+
 ### Integration with react-markdown
 [View docs →](https://github.com/avgvstvs96/react-shiki#integration-with-react-markdown)
 


### PR DESCRIPTION
## Summary
- add `highlightLineNumbers` support for component and hook options
- map highlights to displayed line numbers, including `startingLineNumber`
- add default CSS class/variable and README docs

## Tests
- `vitest run` from `package/`
- `tsc -p package\tsconfig.json --noEmit`
- `biome check` on touched files

Closes #116