### PR TITLE
ci: add node 26 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Node 26 is the current release line (LTS this October), so add it to the build matrix alongside 22 and 24. Covers Maintenance LTS, Active LTS, and Current.