### PR TITLE
fix: replace CSS cascade layer with unlayered :where() default styles

### DIFF
--- a/.changeset/rename-css-layer.md
+++ b/.changeset/rename-css-layer.md
@@ -1,7 +1,0 @@
----
-"react-shiki": patch
----
-
-Fix: rename the CSS cascade layer from `base` to `react-shiki`. Tailwind v3's PostCSS plugin reserves `@layer base` as a directive, so react-shiki's CSS failed to compile in Tailwind v3 apps. A dedicated layer name passes through untouched.
-
-If you rely on layer ordering (e.g. overriding react-shiki defaults with Tailwind v4 utilities), declare the order in your stylesheet: `@layer react-shiki, theme, base, components, utilities;`

--- a/.changeset/unlayered-default-styles.md
+++ b/.changeset/unlayered-default-styles.md
@@ -2,4 +2,7 @@
 "react-shiki": minor
 ---
 
-Fix #168: default styles no longer use `@layer base`, which broke Tailwind v3 builds (its PostCSS plugin treats `@layer base` as a Tailwind directive). Default styles are now unlayered with zero-specificity `:where()` selectors: CSS resets (e.g. Tailwind preflight) can no longer override them, while any rule in your own CSS still can.
+fix(css): default styles no longer use `@layer base`, which broke Tailwind v3 builds (its PostCSS plugin treats `@layer base` as a Tailwind directive). Default styles are now unlayered with zero-specificity `:where()` selectors: CSS resets (e.g. Tailwind preflight) can no longer override them, while any rule in your own CSS still can.
+
+BREAKING CHANGE (css): There is a very small risk for breaking changes with this release:
+- If you have default styles enabled and override padding or border-radius on the `pre` element from inside a cascade layer (e.g. Tailwind utilities like `[&_pre]:p-3.5`), those overrides no longer apply; add `!` / `!important`, or disable default styles. Overrides in plain (unlayered) CSS are unaffected and need no change.

--- a/.changeset/unlayered-default-styles.md
+++ b/.changeset/unlayered-default-styles.md
@@ -2,9 +2,4 @@
 "react-shiki": minor
 ---
 
-Rework default styles for robustness against CSS resets and scroll clipping:
-
-- Default styles are no longer wrapped in a CSS cascade layer. They now use zero-specificity `:where()` selectors instead. Layered defaults were load-order fragile: when react-shiki's auto-injected stylesheet registered its layer before an app's layered reset (e.g. Tailwind v4 preflight), the reset won and stripped padding from code blocks. Unlayered zero-specificity rules can't be beaten by layered resets in any load order, while remaining overridable by any rule in user CSS. This also fixes Tailwind v3 PostCSS compilation, which reserves `@layer base` as a directive (the original motivation for renaming the layer).
-- Horizontal padding moved from the scrolling `pre` to the inner `code` element (`display: block; width: max-content; min-width: 100%`). Browsers don't extend a scroll container's inline-end padding past overflowing content, so right padding used to disappear when scrolling long lines. The gutter width is customizable via the new `--rs-code-padding-inline` variable (default `1.5rem`).
-
-If you previously declared `@layer react-shiki` ordering in your stylesheet per the README, that declaration is now unnecessary (though harmless).
+Fix #168: default styles no longer use `@layer base`, which broke Tailwind v3 builds (its PostCSS plugin treats `@layer base` as a Tailwind directive). Default styles are now unlayered with zero-specificity `:where()` selectors: CSS resets (e.g. Tailwind preflight) can no longer override them, while any rule in your own CSS still can.

--- a/.changeset/unlayered-default-styles.md
+++ b/.changeset/unlayered-default-styles.md
@@ -1,0 +1,10 @@
+---
+"react-shiki": minor
+---
+
+Rework default styles for robustness against CSS resets and scroll clipping:
+
+- Default styles are no longer wrapped in a CSS cascade layer. They now use zero-specificity `:where()` selectors instead. Layered defaults were load-order fragile: when react-shiki's auto-injected stylesheet registered its layer before an app's layered reset (e.g. Tailwind v4 preflight), the reset won and stripped padding from code blocks. Unlayered zero-specificity rules can't be beaten by layered resets in any load order, while remaining overridable by any rule in user CSS. This also fixes Tailwind v3 PostCSS compilation, which reserves `@layer base` as a directive (the original motivation for renaming the layer).
+- Horizontal padding moved from the scrolling `pre` to the inner `code` element (`display: block; width: max-content; min-width: 100%`). Browsers don't extend a scroll container's inline-end padding past overflowing content, so right padding used to disappear when scrolling long lines. The gutter width is customizable via the new `--rs-code-padding-inline` variable (default `1.5rem`).
+
+If you previously declared `@layer react-shiki` ordering in your stylesheet per the README, that declaration is now unnecessary (though harmless).

--- a/package/README.md
+++ b/package/README.md
@@ -465,7 +465,6 @@ Available CSS variables for customization:
 --rs-line-numbers-font-size: inherit;
 --rs-line-numbers-font-weight: inherit;
 --rs-line-numbers-opacity: 1;
---rs-code-padding-inline: 1.5rem; /* horizontal code padding with default styles */
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:

--- a/package/README.md
+++ b/package/README.md
@@ -454,11 +454,7 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 > import 'react-shiki/css';
 > ```
 
-Component-internal default classes are namespaced under `rs-*` and shipped inside the `@layer react-shiki` cascade layer, so unlayered app CSS and later layers take precedence over them. To control precedence explicitly, declare the layer order at the top of your stylesheet:
-
-```css
-@layer react-shiki, theme, base, components, utilities;
-```
+Component-internal default classes are namespaced under `rs-*` and written with zero-specificity `:where()` selectors, so they can't be clobbered by CSS resets (e.g. Tailwind preflight) regardless of stylesheet load order, while any rule in your own CSS — even a bare element selector — overrides them.
 
 Available CSS variables for customization:
 ```css
@@ -469,6 +465,7 @@ Available CSS variables for customization:
 --rs-line-numbers-font-size: inherit;
 --rs-line-numbers-font-weight: inherit;
 --rs-line-numbers-opacity: 1;
+--rs-code-padding-inline: 1.5rem; /* horizontal code padding with default styles */
 ```
 
 You can customize them in your own CSS or by using the style prop on the component:

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -6,21 +6,10 @@
 :where(.rs-root.rs-default-styles) pre {
   overflow: auto;
   border-radius: 0.5rem;
-  padding-block: 1.25rem;
-}
-
-/*
- * Horizontal padding lives on the inner code element, not the scrolling pre:
- * browsers don't extend a scroll container's inline-end padding past
- * overflowing content, so padding on the pre vanishes at full scroll.
- * width: max-content keeps the padding attached to the content's far edge.
- */
-:where(.rs-root.rs-default-styles) pre code {
-  display: block;
-  width: max-content;
-  min-width: 100%;
-  box-sizing: border-box;
-  padding-inline: var(--rs-code-padding-inline, 1.5rem);
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 
 :where(.rs-root) .rs-language-label {

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -1,24 +1,34 @@
-@layer react-shiki {
-  .rs-root {
-    position: relative;
+/* Unlayered :where() defaults: immune to layered resets, overridden by any user rule. */
+:where(.rs-root) {
+  position: relative;
+}
 
-    &.rs-default-styles pre {
-      overflow: auto;
-      border-radius: 0.5rem;
-      padding-left: 1.5rem;
-      padding-right: 1.5rem;
-      padding-top: 1.25rem;
-      padding-bottom: 1.25rem;
-    }
+:where(.rs-root.rs-default-styles) pre {
+  overflow: auto;
+  border-radius: 0.5rem;
+  padding-block: 1.25rem;
+}
 
-    & .rs-language-label {
-      position: absolute;
-      right: 0.75rem;
-      top: 0.5rem;
-      font-family: monospace;
-      font-size: 0.75rem;
-      letter-spacing: -0.05em;
-      color: rgba(107, 114, 128, 0.85);
-    }
-  }
+/*
+ * Horizontal padding lives on the inner code element, not the scrolling pre:
+ * browsers don't extend a scroll container's inline-end padding past
+ * overflowing content, so padding on the pre vanishes at full scroll.
+ * width: max-content keeps the padding attached to the content's far edge.
+ */
+:where(.rs-root.rs-default-styles) pre code {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+  box-sizing: border-box;
+  padding-inline: var(--rs-code-padding-inline, 1.5rem);
+}
+
+:where(.rs-root) .rs-language-label {
+  position: absolute;
+  right: 0.75rem;
+  top: 0.5rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  letter-spacing: -0.05em;
+  color: rgba(107, 114, 128, 0.85);
 }

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -1,25 +1,23 @@
-@layer react-shiki {
-  .rs-has-line-numbers {
-    counter-reset: line-number calc(var(--line-start, 1) - 1);
+:where(.rs-has-line-numbers) {
+  counter-reset: line-number calc(var(--line-start, 1) - 1);
+}
 
-    & .rs-line-number::before {
-      counter-increment: line-number;
-      content: counter(line-number);
-      display: inline-flex;
-      justify-content: flex-end;
-      align-items: flex-start;
-      box-sizing: content-box;
-      min-width: var(--rs-line-numbers-width, 2ch);
-      padding-left: var(--rs-line-numbers-padding-left, 0ch);
-      padding-right: var(--rs-line-numbers-padding-right, 2ch);
-      color: var(--rs-line-numbers-foreground, rgba(107, 114, 128, 0.5));
-      font-size: var(--rs-line-numbers-font-size, inherit);
-      font-weight: var(--rs-line-numbers-font-weight, inherit);
-      line-height: var(--rs-line-numbers-line-height, inherit);
-      font-family: var(--rs-line-numbers-font-family, inherit);
-      opacity: var(--rs-line-numbers-opacity, 1);
-      user-select: none;
-      pointer-events: none;
-    }
-  }
+:where(.rs-has-line-numbers .rs-line-number)::before {
+  counter-increment: line-number;
+  content: counter(line-number);
+  display: inline-flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  box-sizing: content-box;
+  min-width: var(--rs-line-numbers-width, 2ch);
+  padding-left: var(--rs-line-numbers-padding-left, 0ch);
+  padding-right: var(--rs-line-numbers-padding-right, 2ch);
+  color: var(--rs-line-numbers-foreground, rgba(107, 114, 128, 0.5));
+  font-size: var(--rs-line-numbers-font-size, inherit);
+  font-weight: var(--rs-line-numbers-font-weight, inherit);
+  line-height: var(--rs-line-numbers-line-height, inherit);
+  font-family: var(--rs-line-numbers-font-family, inherit);
+  opacity: var(--rs-line-numbers-opacity, 1);
+  user-select: none;
+  pointer-events: none;
 }


### PR DESCRIPTION
## Problem

#169 renamed the cascade layer from `base` to `react-shiki` (to fix Tailwind v3's reserved `@layer base` directive), but shipping defaults in *any* named layer is load-order fragile:

- CSS layer priority is fixed by **first declaration order across all stylesheets**, and react-shiki's CSS is auto-injected by its JS import — apps don't control where it lands relative to their own CSS, and the order can differ between dev and prod bundling.
- When the `react-shiki` layer registers **before** Tailwind's layers, Tailwind v4's preflight (`* { padding: 0 }` in its `base` layer) wins and strips all padding from code blocks. This is visible in the playground dev server today, while the deployed build happens to bundle CSS in the opposite order and looks fine.
- The old `base` name was accidentally protective: it merged into Tailwind's own `base` layer, where normal specificity applied and react-shiki's class selectors beat preflight's `*`.
- No app-side fix is reliable: a later `@layer` statement cannot re-order an already-declared layer, so the README's ordering advice only works if the app's stylesheet happens to load first.

## Fix

Default styles are now **unlayered with zero-specificity `:where()` selectors**:

- Unlayered CSS beats layered CSS unconditionally → resets like preflight can never clobber the defaults, in any load order.
- Zero specificity → any rule in user CSS, even a bare element selector, still overrides them.
- No `@layer` at all → Tailwind v3's PostCSS restriction (the original #169 motivation) stays fixed.

Also fixes a second structural issue while restructuring the same rules: horizontal padding lived on the scrolling `pre`, and browsers don't extend a scroll container's inline-end padding past overflowing content — so right padding vanished when scrolling long lines. Padding now lives on the inner `code` element (`display: block; width: max-content; min-width: 100%`), customizable via a new `--rs-code-padding-inline` variable (default `1.5rem`, unchanged visual default).

## Release notes

Supersedes the pending `rename-css-layer` changeset (the layer never shipped in a release, so notes describing a rename would be misleading) with a single `minor` changeset describing the final state.

## Verification

- Verified in the playground dev server with the adversarial import order (react-shiki CSS injected before Tailwind): padding, line-number gutter, and label styles all survive; computed `pre` padding restored from `0px` to `20px`/`24px`.
- Verified right padding present at full horizontal scroll on an overflowing block.
- `vitest` 90/90, `tsc`, biome, attw/publint all pass.