### PR TITLE
ci: support Claude review on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,10 @@
 name: Claude Code Review
 
+# pull_request_target (not pull_request) so fork PRs get OIDC and secrets,
+# which GitHub withholds from fork-triggered pull_request runs. It executes
+# in the base repo's context, so fork PRs only run via the label gate below.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
@@ -10,13 +13,15 @@ concurrency:
 
 jobs:
   claude-review:
-    # Auto-runs skip drafts and bot PRs; label events run only for the two
-    # trigger labels (labels still work on bot PRs since the actor is human).
-    # Adding labels requires write access, so PR authors can't trigger runs.
+    # Auto-runs are same-repo only and skip drafts and bot PRs; fork PRs
+    # review only via the two trigger labels (labels still work on bot PRs
+    # since the actor is human). Adding labels requires write access, so PR
+    # authors can't trigger runs against pull_request_target's secrets.
     if: >-
       github.event.action == 'labeled'
       && contains(fromJSON('["fable-review", "opus-review"]'), github.event.label.name)
       || github.event.action != 'labeled'
+      && github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.draft == false
       && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
@@ -72,6 +77,10 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         uses: actions/checkout@v6
         with:
+          # pull_request_target checks out the base branch by default;
+          # review the PR's code instead. Safe to check out untrusted code
+          # here: allowedTools only reads the PR via gh, never executes it.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

Adding the \`fable-review\` label to fork PR #172 failed with \`Unable to get ACTIONS_ID_TOKEN_REQUEST_URL\`: GitHub withholds OIDC tokens **and** repo secrets from \`pull_request\` runs triggered by forks, regardless of declared permissions — so both the action's GitHub token exchange and \`CLAUDE_CODE_OAUTH_TOKEN\` were unavailable. Same-repo PRs were unaffected, which is why #176 tested fine.

- Switch the trigger to \`pull_request_target\`, which runs in the base repo's context where OIDC and secrets are available for fork PRs
- Restrict auto-runs to same-repo PRs; fork PRs review only via the \`fable-review\` / \`opus-review\` labels, which require write access to apply — no secret exposure to unreviewed fork code
- Check out the PR head explicitly (\`pull_request_target\` defaults to the base branch); safe since allowedTools only reads the PR via \`gh\`, never executes it

## Tests

- \`actionlint\` clean (only pre-existing SC2016 info notes in the annotate step)