### PR TITLE
ci: pass github_token to Claude review, skipping OIDC exchange that 401s on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,12 +26,11 @@ jobs:
       && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # No id-token: the action gets github_token directly, skipping the OIDC
-    # exchange that Anthropic rejects for fork-PR (pull_request_target) runs.
     permissions:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - name: Gate review and select model
@@ -59,9 +58,11 @@ jobs:
             gh api -X DELETE "repos/$REPO/issues/$PR/labels/$LABEL" || true
           else
             # The sticky review comment's updated_at is the last-review time;
-            # no comment yet (e.g. freshly opened PR) means review now
+            # no comment yet (e.g. freshly opened PR) means review now.
+            # claude[bot] is right here: this branch only runs for same-repo
+            # PRs, which review via the OIDC path.
             LAST=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]") | .updated_at] | max // empty')
+              --jq '[.[] | select(.user.login == "claude[bot]") | .updated_at] | max // empty')
             if [ -n "$LAST" ]; then
               ELAPSED=$(( $(date +%s) - $(date -d "$LAST" +%s) ))
               if [ "$ELAPSED" -lt "$COOLDOWN" ]; then
@@ -90,9 +91,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Skip the OIDC → app-token exchange (401s on fork PRs); comments
-          # post as github-actions[bot] instead of claude[bot] as a result
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Fork PRs only: Anthropic's OIDC → app-token exchange 401s in
+          # fork contexts, so hand the action a token directly. Fork reviews
+          # post as github-actions[bot]; same-repo PRs take the OIDC path
+          # (empty string = unset) and keep posting as claude[bot].
+          github_token: ${{ github.event.pull_request.head.repo.full_name != github.repository && secrets.GITHUB_TOKEN || '' }}
 
           claude_args: |
             --model ${{ steps.gate.outputs.model }}
@@ -137,6 +140,9 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           MODEL: ${{ steps.gate.outputs.model }}
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+          # Matches the review's author: fork PRs run with github_token and
+          # post as github-actions[bot]; same-repo PRs post as claude[bot]
+          BOT: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'github-actions[bot]' || 'claude[bot]' }}
         run: |
           NAME="Fable 5"
           [ "$MODEL" = "opus" ] && NAME="Opus 4.8"
@@ -150,7 +156,7 @@ jobs:
           fi
 
           COMMENT=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]")] | last')
+            --jq '[.[] | select(.user.login == "'"$BOT"'")] | last')
           [ -n "$COMMENT" ] && [ "$COMMENT" != "null" ] || exit 0
 
           {

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,6 @@
 name: Claude Code Review
 
-# pull_request_target (not pull_request) so fork PRs get OIDC and secrets,
+# pull_request_target (not pull_request) so fork PRs get repo secrets,
 # which GitHub withholds from fork-triggered pull_request runs. It executes
 # in the base repo's context, so fork PRs only run via the label gate below.
 on:
@@ -26,11 +26,12 @@ jobs:
       && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # No id-token: the action gets github_token directly, skipping the OIDC
+    # exchange that Anthropic rejects for fork-PR (pull_request_target) runs.
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       - name: Gate review and select model
@@ -60,7 +61,7 @@ jobs:
             # The sticky review comment's updated_at is the last-review time;
             # no comment yet (e.g. freshly opened PR) means review now
             LAST=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-              --jq '[.[] | select(.user.login == "claude[bot]") | .updated_at] | max // empty')
+              --jq '[.[] | select(.user.login == "github-actions[bot]") | .updated_at] | max // empty')
             if [ -n "$LAST" ]; then
               ELAPSED=$(( $(date +%s) - $(date -d "$LAST" +%s) ))
               if [ "$ELAPSED" -lt "$COOLDOWN" ]; then
@@ -89,6 +90,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC → app-token exchange (401s on fork PRs); comments
+          # post as github-actions[bot] instead of claude[bot] as a result
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           claude_args: |
             --model ${{ steps.gate.outputs.model }}
@@ -146,7 +150,7 @@ jobs:
           fi
 
           COMMENT=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-            --jq '[.[] | select(.user.login == "claude[bot]")] | last')
+            --jq '[.[] | select(.user.login == "github-actions[bot]")] | last')
           [ -n "$COMMENT" ] && [ "$COMMENT" != "null" ] || exit 0
 
           {


### PR DESCRIPTION
## Summary

Follow-up to #177. The fork-PR review run now gets past permissions but dies at Anthropic's app-token exchange: `401 Unauthorized - Invalid OIDC token` ([run](https://github.com/AVGVSTVS96/react-shiki/actions/runs/28724907083)). Anthropic's backend rejects OIDC tokens minted in fork-PR / `pull_request_target` contexts — a known limitation ([same failure in ag2](https://github.com/ag2ai/ag2/issues/2172)); the action's documented workaround is passing `github_token` explicitly, which skips the exchange.

**Scoped to fork PRs only** — same-repo PRs keep the OIDC path and the `claude[bot]` identity:

- `github_token` is passed conditionally: `head.repo != repository ? GITHUB_TOKEN : ''` (empty = unset, action falls through to OIDC)
- Cooldown gate keeps matching `claude[bot]` — it only runs on the auto-run path, which is same-repo only
- Annotate step picks the author to look for per event: `github-actions[bot]` for forks, `claude[bot]` otherwise

## Trade-off

Fork-PR reviews post as **github-actions[bot]**; the model footer still identifies which model reviewed. Your own PRs are unchanged.

## Tests

- `actionlint` clean (pre-existing SC2016 info notes only)