### PR TITLE
ci: always publish review summary, manage inline thread lifecycle

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -81,8 +81,10 @@ jobs:
             # updated_at is the last-review time; no comment yet (e.g.
             # freshly opened PR) means review now. claude[bot] is right
             # here: this branch only runs for same-repo PRs.
-            LAST=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-              --jq '[.[] | select(.user.login == "claude[bot]") | .updated_at] | max // empty')
+            # --slurp wraps pages in an outer array so max is global, not
+            # per-page
+            LAST=$(gh api --paginate --slurp "repos/$REPO/issues/$PR/comments" \
+              | jq -r '[.[][] | select(.user.login == "claude[bot]") | .updated_at] | max // empty')
             if [ -n "$LAST" ]; then
               ELAPSED=$(( $(date +%s) - $(date -d "$LAST" +%s) ))
               if [ "$ELAPSED" -lt "$COOLDOWN" ]; then
@@ -121,7 +123,7 @@ jobs:
 
           claude_args: |
             --model ${{ steps.gate.outputs.model }}
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)${{ github.event_name == 'pull_request' && ',Bash(gh api graphql:*)' || '' }}"
 
           prompt: |
             REPO: ${{ github.repository }}
@@ -141,10 +143,11 @@ jobs:
 
             Be constructive and helpful in your feedback.
 
-            ${{ github.event_name == 'pull_request_target' &&
-            '
+            ${{ github.event_name == 'pull_request' &&
+            format('Inline comments: on re-reviews, leave open threads equal to your current findings. Reply with a one-line reason and resolve (GraphQL) your prior threads that are addressed or superseded — post fresh comments for superseded findings rather than editing. Never resolve human-authored threads.
 
-            IMPORTANT: When finished, post your complete review as a PR comment using `gh pr comment`. Nothing else will publish it for you — a review that is not posted with `gh pr comment` is lost.' || '' }}
+            IMPORTANT: When finished, publish your review summary with `gh pr comment {0} --edit-last --create-if-none --body ...` — nothing else publishes it for you, and an unposted review fails this workflow. Omit any model footer; one is appended for you.', github.event.pull_request.number) ||
+            format('IMPORTANT: When finished, post your complete review summary with `gh pr comment {0} --body ...` — nothing else publishes it for you, and an unposted review fails this workflow. Omit any model footer; one is appended for you.', github.event.pull_request.number) }}
 
             ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
             '
@@ -184,8 +187,8 @@ jobs:
 
           # Only accept a comment created/updated during this run — a
           # stale one means Claude finished without publishing anything
-          COMMENT=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-            --jq '[.[] | select(.user.login == "'"$BOT"'" and .updated_at >= "'"$STARTED"'")] | last')
+          COMMENT=$(gh api --paginate --slurp "repos/$REPO/issues/$PR/comments" \
+            | jq '[.[][] | select(.user.login == "'"$BOT"'" and .updated_at >= "'"$STARTED"'")] | max_by(.updated_at)')
           if [ -z "$COMMENT" ] || [ "$COMMENT" = "null" ]; then
             echo "::error::Review ran but no $BOT comment was posted since $STARTED — re-add the label to retry"
             exit 1


### PR DESCRIPTION
## Problem

Two same-repo review runs on #146 completed without posting the summary comment — the publish instruction was only injected for fork (`pull_request_target`) runs, so on same-repo PRs Claude published only if it spontaneously decided to. The verify step correctly failed those runs.

## Changes

**Publish instruction is now unconditional**, split by event:
- Same-repo: `gh pr comment N --edit-last --create-if-none` — one sticky summary per PR, updated in place (also what the cooldown gate's `updated_at` read assumes)
- Fork: plain `gh pr comment` — `--edit-last` under the shared `github-actions[bot]` identity could clobber another workflow's comment

**Inline thread lifecycle** (same-repo only): `Bash(gh api graphql:*)` added to allowedTools with instructions to keep open threads equal to current findings — reply with a reason + resolve addressed/superseded threads, post fresh comments rather than editing, never touch human threads. GraphQL is withheld from fork runs: with the repo token in `pull_request_target` context, prompt injection in untrusted PR content would otherwise escalate from bad comments to arbitrary write mutations.

**Pagination fix** in gate + verify: `gh api --paginate --jq` applies the filter per page, so `max`/`last` weren't global. Now slurps pages and aggregates across all.

## Verification

- GraphQL query/mutations live-tested against PR #146 (list, reply, resolve — the three addressed threads there were resolved with these exact commands)
- Both jq filters live-tested, including the no-match → `null` path
- `--edit-last --create-if-none` confirmed available (gh 2.95)
- This PR's own review run exercises the same-repo publish path end-to-end