### PR TITLE
fix: bleed highlighted-line backgrounds into pre padding

### DIFF
--- a/.changeset/highlight-line-numbers.md
+++ b/.changeset/highlight-line-numbers.md
@@ -2,4 +2,11 @@
 "react-shiki": minor
 ---
 
-feat: add `highlightLineNumbers` option to highlight specific lines by displayed line number (respects `startingLineNumber`). Highlighted lines get the `rs-highlighted-line` class; defaults are theme-adaptive and customizable via `--rs-highlighted-line-background` and `--rs-highlighted-line-number-foreground`.
+feat: add `highlightLineNumbers` option to highlight specific lines by displayed line number (respects `startingLineNumber`)
+
+Highlighted lines get the `rs-highlighted-line` class. The highlight color adapts to the active theme, deriving from its text color. With default styles, backgrounds automatically extend into the pre's horizontal padding so they reach the container edges.
+
+New CSS variables:
+
+- `--rs-highlighted-line-background`: highlight color (default: theme text color at 10% opacity)
+- `--rs-highlighted-line-number-foreground`: line number color on highlighted lines (default: theme text color at 65% opacity)

--- a/package/README.md
+++ b/package/README.md
@@ -474,6 +474,8 @@ Available CSS variables for customization:
 --rs-highlighted-line-number-foreground: color-mix(in srgb, currentColor 65%, transparent);
 ```
 
+With default styles, highlighted-line backgrounds automatically extend into the `pre`'s horizontal padding, reaching the container edges. When styling the `pre` yourself, highlights cover the code content area.
+
 You can customize them in your own CSS or by using the style prop on the component:
 ```tsx
 <ShikiHighlighter 

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -6,14 +6,13 @@
 :where(.rs-root.rs-default-styles) pre {
   overflow: auto;
   border-radius: 0.5rem;
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
-  padding-top: 1.25rem;
-  padding-bottom: 1.25rem;
+  padding-inline: 1.5rem;
+  padding-block: 1.25rem;
 }
 
 :where(.rs-root) .rs-language-label {
   position: absolute;
+  z-index: 1;
   right: 0.75rem;
   top: 0.5rem;
   font-family: monospace;

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -22,8 +22,6 @@
   pointer-events: none;
 }
 
-/* Size the code element to its content so line backgrounds
-   span the full scroll width, not just the visible area. */
 :where(.rs-has-highlighted-lines) {
   display: block;
   width: fit-content;
@@ -31,13 +29,21 @@
 }
 
 :where(.rs-highlighted-line) {
-  display: inline-block;
-  width: 100%;
-  min-height: 1lh;
-  background-color: var(
+  --_rs-hl-background: var(
     --rs-highlighted-line-background,
     color-mix(in srgb, currentColor 10%, transparent)
   );
+  display: inline-block;
+  width: 100%;
+  min-height: 1lh;
+  background-color: var(--_rs-hl-background);
+}
+
+/* Full bleed: the 100vw outset paints into the pre's padding, clipped by its overflow. */
+:where(.rs-default-styles) .rs-highlighted-line {
+  background-color: transparent;
+  border-image: linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0
+    100vw;
 }
 
 :where(.rs-has-line-numbers .rs-highlighted-line)::before {


### PR DESCRIPTION
## Problem

Highlighted-line backgrounds are painted by the line spans inside `code`, so they stop at the content box and never reach into the `pre`'s horizontal padding, leaving unhighlighted 1.5rem gutters on both sides with default styles.

## Fix

With default styles, highlighted lines paint their background as a `border-image` with a `100vw` horizontal outset:

```css
:where(.rs-default-styles) .rs-highlighted-line {
  background-color: transparent;
  border-image: linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0 100vw;
}
```

`fill` paints the line box, the outset bleeds into the padding, and the default styles' `overflow: auto` clips it at exactly the padding edge. Works with any padding value, nothing to keep in sync, and it's pure ink overflow: no layout change, no scrollbar pollution, gutters stay filled at both horizontal scroll extremes.

Scoped to default styles: custom-styled pres keep the plain content-box background, so nothing is injected into user containers. The language label gets `z-index: 1` so it stays above any pre that forms a stacking context via user styles.

## Verified

Playground checked visually after rebuild: full bleed with and without line numbers, gutters filled at max horizontal scroll, language label visible above the pre, custom-styled blocks unaffected.