### PR TITLE
fix: trim language ids before resolving

### DIFF
--- a/.changeset/pink-experts-battle.md
+++ b/.changeset/pink-experts-battle.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+fix: trim language ids before resolving

--- a/package/src/lib/language.ts
+++ b/package/src/lib/language.ts
@@ -114,7 +114,8 @@ export const resolveLanguage = (
     primaryLang = lang;
   } else {
     // Language is string
-    const lowerLang = lang.toLowerCase();
+    const normalizedLang = lang.trim();
+    const lowerLang = normalizedLang.toLowerCase();
     const matches = (str: string | undefined): boolean =>
       str?.toLowerCase() === lowerLang;
 
@@ -133,16 +134,16 @@ export const resolveLanguage = (
     );
 
     if (customMatch) {
-      languageId = customMatch.name || lang;
+      languageId = customMatch.name || normalizedLang;
       primaryLang = customMatch;
-    } else if (langAliases?.[lang]) {
+    } else if (langAliases?.[normalizedLang]) {
       // Language is aliased
-      languageId = langAliases[lang];
-      primaryLang = langAliases[lang];
+      languageId = langAliases[normalizedLang];
+      primaryLang = langAliases[normalizedLang];
     } else {
       // For any other string, pass it through to the factory
-      languageId = lang;
-      primaryLang = lang;
+      languageId = normalizedLang;
+      primaryLang = normalizedLang;
     }
   }
 

--- a/package/tests/language.test.ts
+++ b/package/tests/language.test.ts
@@ -110,6 +110,13 @@ describe('resolveLanguage', () => {
     });
   });
 
+  test('trims language strings before custom language lookup', () => {
+    expect(resolveLanguage('  my-language  ', customLanguage)).toEqual({
+      languageId: 'my-language',
+      langsToLoad: [customLanguage],
+    });
+  });
+
   test('resolves custom language by scopeName tail', () => {
     const scopeNameLanguage = {
       name: 'scope-based-language',
@@ -147,11 +154,31 @@ describe('resolveLanguage', () => {
     });
   });
 
+  test('trims language strings before alias lookup', () => {
+    expect(
+      resolveLanguage('  mylang  ', undefined, {
+        mylang: 'javascript',
+      })
+    ).toEqual({
+      languageId: 'javascript',
+      langsToLoad: ['javascript'],
+    });
+  });
+
   test('falls back to passthrough when no resolver match exists', () => {
     expect(resolveLanguage('plain-old-lang', customLanguage)).toEqual({
       languageId: 'plain-old-lang',
       langsToLoad: ['plain-old-lang', customLanguage],
     });
+  });
+
+  test('trims passthrough language ids', () => {
+    expect(resolveLanguage('  plain-old-lang  ', customLanguage)).toEqual(
+      {
+        languageId: 'plain-old-lang',
+        langsToLoad: ['plain-old-lang', customLanguage],
+      }
+    );
   });
 
   test('gives custom language precedence over alias map', () => {


### PR DESCRIPTION
## What changed

- Trim string language ids before resolving custom languages, alias mappings, or passthrough bundled ids.
- Add regression coverage for padded custom language names, alias lookups, and passthrough ids.

## Why

`ShikiHighlighter` already trims string languages for the visible label, but `resolveLanguage()` used the raw string for matching and loading. A value like `" javascript "` could display as `javascript` while resolving as an unknown language.

## Verification

- `pnpm --filter react-shiki test -- language.test.ts`
- `pnpm --filter react-shiki lint`
- `git diff --check`
