### PR TITLE
fix: match language aliases case-insensitively

### DIFF
--- a/.changeset/bright-aliases-resolve.md
+++ b/.changeset/bright-aliases-resolve.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Fix case-insensitive matching for language aliases.

--- a/package/src/lib/language.ts
+++ b/package/src/lib/language.ts
@@ -136,14 +136,20 @@ export const resolveLanguage = (
     if (customMatch) {
       languageId = customMatch.name || normalizedLang;
       primaryLang = customMatch;
-    } else if (langAliases?.[normalizedLang]) {
-      // Language is aliased
-      languageId = langAliases[normalizedLang];
-      primaryLang = langAliases[normalizedLang];
     } else {
-      // For any other string, pass it through to the factory
-      languageId = normalizedLang;
-      primaryLang = normalizedLang;
+      const alias = Object.entries(langAliases ?? {}).find(([name]) =>
+        matches(name)
+      )?.[1];
+
+      if (alias) {
+        // Language is aliased
+        languageId = alias;
+        primaryLang = alias;
+      } else {
+        // For any other string, pass it through to the factory
+        languageId = normalizedLang;
+        primaryLang = normalizedLang;
+      }
     }
   }
 

--- a/package/tests/language.test.ts
+++ b/package/tests/language.test.ts
@@ -165,6 +165,17 @@ describe('resolveLanguage', () => {
     });
   });
 
+  test('matches alias map keys case-insensitively', () => {
+    expect(
+      resolveLanguage('MyLang', undefined, {
+        mylang: 'javascript',
+      })
+    ).toEqual({
+      languageId: 'javascript',
+      langsToLoad: ['javascript'],
+    });
+  });
+
   test('falls back to passthrough when no resolver match exists', () => {
     expect(resolveLanguage('plain-old-lang', customLanguage)).toEqual({
       languageId: 'plain-old-lang',


### PR DESCRIPTION
## Summary

- match `langAlias` keys case-insensitively, consistent with custom language matching
- add a regression test and patch changeset

## Why

`resolveLanguage` normalizes custom-language names without regard to case, but alias-map lookup required an exact key match. As a result, a language input such as `MyLang` bypassed an alias registered as `mylang` and fell through to the highlighter.

## Validation

- `pnpm --filter react-shiki exec vitest run tests/language.test.ts`
- `pnpm --filter react-shiki exec biome lint src/lib/language.ts tests/language.test.ts`
- `tsc` via the package check command

The repository-wide Biome format phase reports pre-existing CRLF line-ending differences in untouched files.
