### PR TITLE
fix: css pruned from webpack prod builds, non-zero :where() specificity

### DIFF
--- a/.changeset/css-side-effects.md
+++ b/.changeset/css-side-effects.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Fix: styles silently dropped from webpack production builds. `sideEffects` still listed pre-0.10 source paths instead of the published `dist/style.css`, so webpack tree-shook the stylesheet import with no warning (affects 0.10.0–0.11.0). Now `**/*.css`.

--- a/.changeset/css-specificity.md
+++ b/.changeset/css-specificity.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Fix(css): three default-style selectors left part of the selector outside `:where()` (`pre`, language label, highlighted line), giving them real specificity that could tie with or beat user rules depending on stylesheet order. All selectors are now fully wrapped and zero-specificity, so any user rule always wins.

--- a/package/package.json
+++ b/package/package.json
@@ -32,8 +32,7 @@
     "src/styles/css.d.ts"
   ],
   "sideEffects": [
-    "src/styles/component.css",
-    "src/styles/features.css"
+    "**/*.css"
   ],
   "publishConfig": {
     "access": "public",

--- a/package/src/styles/component.css
+++ b/package/src/styles/component.css
@@ -3,14 +3,14 @@
   position: relative;
 }
 
-:where(.rs-root.rs-default-styles) pre {
+:where(.rs-root.rs-default-styles pre) {
   overflow: auto;
   border-radius: 0.5rem;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
 }
 
-:where(.rs-root) .rs-language-label {
+:where(.rs-root .rs-language-label) {
   position: absolute;
   z-index: 1;
   right: 0.75rem;

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -40,10 +40,10 @@
 }
 
 /* Full bleed: the 100vw outset paints into the pre's padding, clipped by its overflow. */
-:where(.rs-default-styles) .rs-highlighted-line {
+:where(.rs-default-styles .rs-highlighted-line) {
   background-color: transparent;
-  border-image: linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0
-    100vw;
+  border-image:
+    linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0 100vw;
 }
 
 :where(.rs-has-line-numbers .rs-highlighted-line)::before {

--- a/package/tsdown.config.ts
+++ b/package/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig((options) => {
     dts: true,
     sourcemap: true,
     clean: !dev,
-    css: { inject: true },
+    css: { inject: true, minify: true },
     deps: {
       onlyBundle: ['@types/hast', '@types/unist'],
     },


### PR DESCRIPTION
## Problem

Two independent CSS bugs, both shipping since recent releases:

1. **Webpack production builds silently drop all react-shiki styles** (0.10.0–0.11.0). `sideEffects` still lists pre-tsdown source paths (`src/styles/*.css`), which match nothing in the published package — the actual stylesheet import resolves to `dist/style.css`. Webpack marks it side-effect-free and tree-shakes it with no warning: zero CSS assets emitted, unstyled code blocks in prod while dev looks fine.

2. **Three default-style selectors aren't actually zero-specificity** (0.11.0). Parts of the selector sit outside `:where()`:

   ```css
   :where(.rs-root.rs-default-styles) pre            /* 0-0-1 */
   :where(.rs-root) .rs-language-label               /* 0-1-0 */
   :where(.rs-default-styles) .rs-highlighted-line   /* 0-1-0 */
   ```

   so they tie with or beat user rules depending on stylesheet order, breaking the "any user rule always wins" contract from #174.

## Fix

- `sideEffects`: `["**/*.css"]`
- Fully wrap the three selectors: `:where(.rs-root.rs-default-styles pre)` etc. — same matching, zero specificity
- Also enable `css.minify` (CSS only; JS output stays unminified per #58)

## Verification

- Minimal webpack 5.108 production repro against published 0.11.0: no `.css` asset emitted with current `sideEffects`; both `**/*.css` and `./dist/style.css` restore it (1.9 KiB with all `rs-*` rules). Confirmed mechanism via `optimization.sideEffects: false` control.
- vitest 104/104, tsc, biome, attw/publint all pass; `dist/style.css` minified with fixed selectors.