### PR TITLE
ci: run check (tsc + biome) on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: Check
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.18.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm --filter react-shiki install --frozen-lockfile
+
+      - name: Check
+        run: pnpm --filter react-shiki check

--- a/package/src/styles/features.css
+++ b/package/src/styles/features.css
@@ -42,8 +42,8 @@
 /* Full bleed: the 100vw outset paints into the pre's padding, clipped by its overflow. */
 :where(.rs-default-styles) .rs-highlighted-line {
   background-color: transparent;
-  border-image: linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0
-    100vw;
+  border-image:
+    linear-gradient(var(--_rs-hl-background) 0 0) fill 0 / 0 / 0 100vw;
 }
 
 :where(.rs-has-line-numbers .rs-highlighted-line)::before {


### PR DESCRIPTION
## Summary

CI workflows only ran `build` and `test`, so type errors and lint/format violations were never caught on PRs.

- Add a **Check** workflow that runs `pnpm --filter react-shiki check` (`tsc && biome check .`) on every pull request, mirroring the structure of the existing Build/Test workflows
- Fix the one existing Biome formatting error in `package/src/styles/features.css` that the new check surfaces (line wrapping on the `border-image` declaration), so the workflow starts green

## Test plan

- `pnpm --filter react-shiki check` passes locally after the format fix
- The new Check workflow should run and pass on this PR