### PR TITLE
perf: scope style injection to usage, tree-shake component styles

### DIFF
--- a/.changeset/scoped-style-injection.md
+++ b/.changeset/scoped-style-injection.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Style injection is now scoped to what is actually used: component styles install before layout on first mount and tree-shake out of hook-only bundles entirely, while line-number/highlight styles install only when those options are enabled. Hook consumers that use no line features inject no CSS at all.

--- a/package/README.md
+++ b/package/README.md
@@ -442,7 +442,7 @@ Line numbers are CSS-based and can be customized with CSS variables:
   {code}
 </ShikiHighlighter>
 
-// Hook (styles are injected automatically, same as the component)
+// Hook (line-number styles inject automatically when enabled)
 const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
   showLineNumbers: true,
   startingLineNumber: 0,
@@ -451,12 +451,12 @@ const highlightedCode = useShikiHighlighter(code, "javascript", "github-dark", {
 ```
 
 > [!NOTE]
-> No CSS import is needed: line-number and highlight styles are injected automatically for both the component and the hook.
+> No CSS import is needed: the shared highlighting hook injects line-number and highlight styles automatically when those features are enabled, including when used through the component.
 > To customize them, override `.rs-line-number` (line `span`), `.rs-highlighted-line` (line `span`), and `.rs-has-line-numbers` / `.rs-has-highlighted-lines` (container `code` element) in your own CSS.
 
 `highlightLineNumbers` uses displayed line numbers, so it works with `startingLineNumber`.
 
-Component styles are embedded in the JS and injected automatically at runtime — no CSS import or bundler configuration needed. The complete compiled stylesheet is also exported as `react-shiki/css` for explicit stylesheet pipelines or environments where runtime injection is unsuitable.
+Component styles are embedded in the JS and installed automatically when the component mounts — no CSS import or bundler configuration needed. Injection is scoped to usage: component styles tree-shake out of hook-only bundles entirely, while line-number/highlight styles are installed only when those options are enabled. The complete compiled stylesheet is also exported as `react-shiki/css` for build-time CSS pipelines or as an externally loaded fallback. Importing it does not disable automatic runtime injection.
 
 Component-internal default classes are namespaced under `rs-*` and written with zero-specificity `:where()` selectors, so they can't be clobbered by CSS resets (e.g. Tailwind preflight) regardless of stylesheet load order, while any rule in your own CSS — even a bare element selector — overrides them.
 

--- a/package/package.json
+++ b/package/package.json
@@ -100,6 +100,7 @@
     "html-react-parser": "^6.1.3",
     "jsdom": "^29.1.1",
     "publint": "^0.3.21",
+    "rolldown": "^1.2.0",
     "tsdown": "^0.22.9",
     "vitest": "^4.1.9"
   }

--- a/package/scripts/check-package.mjs
+++ b/package/scripts/check-package.mjs
@@ -2,12 +2,15 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { rolldown } from 'rolldown';
 
 const dist = fileURLToPath(new URL('../dist/', import.meta.url));
 const fail = (msg) => {
   console.error(`✗ ${msg}`);
   process.exitCode = 1;
 };
+
+const entries = ['index.mjs', 'web.mjs', 'core.mjs'];
 
 for (const file of await readdir(dist)) {
   if (!file.endsWith('.mjs')) continue;
@@ -19,11 +22,15 @@ for (const file of await readdir(dist)) {
   ) {
     fail(`${file} contains a CSS import`);
   }
-  // Style injection survives tree-shaking only because bundlers must
-  // retain a factory call that isn't annotated pure
-  if (/__PURE__\s*\*\/\s*createShikiHighlighterComponent\(/.test(code)) {
+}
+
+// Tree-shaking hook-only bundles depends on the factory calls staying
+// pure-annotated (injection happens when the component mounts)
+for (const entry of entries) {
+  const code = await readFile(join(dist, entry), 'utf8');
+  if (!/__PURE__\s*\*\/\s*createShikiHighlighterComponent\(/.test(code)) {
     fail(
-      `${file} has a PURE-annotated factory call, bundlers would strip style injection`
+      `${entry} factory call lost its PURE annotation, hook-only consumers would bundle the component`
     );
   }
 }
@@ -37,7 +44,7 @@ for (const selector of ['.rs-root', '.rs-highlighted-line']) {
   }
 }
 
-for (const entry of ['index.mjs', 'web.mjs', 'core.mjs']) {
+for (const entry of entries) {
   try {
     await import(pathToFileURL(join(dist, entry)).href);
   } catch (error) {
@@ -45,6 +52,48 @@ for (const entry of ['index.mjs', 'web.mjs', 'core.mjs']) {
       `plain Node ESM import of dist/${entry} failed: ${error.message}`
     );
   }
+}
+
+// Bundle dist as a consumer would and verify what tree-shaking keeps:
+// hook-only bundles must drop the component and its styles entirely
+const bundleDist = async (source) => {
+  const bundle = await rolldown({
+    input: 'virtual-entry',
+    external: (id) =>
+      id !== 'virtual-entry' &&
+      !id.startsWith('file:') &&
+      !id.startsWith('.') &&
+      !id.startsWith('/'),
+    logLevel: 'silent',
+    plugins: [
+      {
+        name: 'virtual-entry',
+        resolveId: (id) => (id === 'virtual-entry' ? id : null),
+        load: (id) => (id === 'virtual-entry' ? source : null),
+      },
+    ],
+  });
+  const { output } = await bundle.generate({ format: 'esm' });
+  await bundle.close();
+  return output[0].code;
+};
+
+const indexPath = pathToFileURL(join(dist, 'index.mjs')).href;
+const hookOnly = await bundleDist(
+  `export { useShikiHighlighter } from ${JSON.stringify(indexPath)};`
+);
+if (hookOnly.includes('rs-root')) {
+  fail('hook-only bundle retains the component or its styles');
+}
+if (!hookOnly.includes('.rs-highlighted-line')) {
+  fail('hook-only bundle dropped the gated feature styles');
+}
+
+const withComponent = await bundleDist(
+  `export { ShikiHighlighter } from ${JSON.stringify(indexPath)};`
+);
+if (!withComponent.includes(':where(.rs-root)')) {
+  fail('component bundle dropped the component styles');
 }
 
 if (process.exitCode) process.exit(process.exitCode);

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -90,7 +90,6 @@ export const useShikiHighlighter: UseShikiHighlighter = (
  * ShikiHighlighter component using a custom highlighter.
  * Requires a highlighter to be provided.
  */
-export const ShikiHighlighter = createShikiHighlighterComponent(
-  useShikiHighlighter
-);
+export const ShikiHighlighter =
+  /*#__PURE__*/ createShikiHighlighterComponent(useShikiHighlighter);
 export default ShikiHighlighter;

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -64,7 +64,6 @@ export const useShikiHighlighter: UseShikiHighlighter = (
  * ShikiHighlighter component using the full bundle.
  * Includes all languages and themes for maximum compatibility.
  */
-export const ShikiHighlighter = createShikiHighlighterComponent(
-  useShikiHighlighter
-);
+export const ShikiHighlighter =
+  /*#__PURE__*/ createShikiHighlighterComponent(useShikiHighlighter);
 export default ShikiHighlighter;

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -1,7 +1,3 @@
-import styles from '../styles/index.css?inline';
-// Side-effect import so tsdown emits dist/style.css for the ./css export;
-// stripped from the built JS, guarded by check:package
-import '../styles/index.css';
 import { clsx } from 'clsx';
 
 import type {
@@ -13,29 +9,7 @@ import type {
   UseShikiHighlighter,
 } from './types';
 import { forwardRef } from 'react';
-
-let stylesInjected = false;
-
-/**
- * Must run inside the factory, not at module scope: bundlers may drop
- * top-level statements in side-effect-free packages, but never a call
- * whose result is a used export.
- */
-const injectStyles = () => {
-  if (stylesInjected || typeof document === 'undefined') return;
-  stylesInjected = true;
-  try {
-    // Not governed by CSP style-src in current browsers, unlike the <style> fallback
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(styles);
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
-  } catch {
-    const style = document.createElement('style');
-    style.dataset.reactShiki = '';
-    style.textContent = styles;
-    document.head.append(style);
-  }
-};
+import { useComponentStyles } from './styles';
 
 let warnedTokensOutputFormat = false;
 
@@ -152,7 +126,6 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
 export const createShikiHighlighterComponent = (
   useShikiHighlighterImpl: UseShikiHighlighter
 ) => {
-  injectStyles();
   return forwardRef<HTMLElement, ShikiHighlighterProps>(
     (
       {
@@ -180,6 +153,10 @@ export const createShikiHighlighterComponent = (
       },
       ref
     ) => {
+      // Kept inside the component so hook-only bundles can tree-shake it
+      // together with the component CSS.
+      useComponentStyles();
+
       const options: HighlighterOptions = {
         delay,
         transformers,

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -17,6 +17,7 @@ import type {
 } from './types';
 
 import { throttleHighlighting, useStableValue } from './utils';
+import { useFeatureStyles } from './styles';
 import {
   getEmbeddedLanguages,
   resolveLanguage,
@@ -83,6 +84,14 @@ export const useHighlight = <F extends OutputFormat = 'react'>(
 ): HighlightResult<F> => {
   const [highlightedCode, setHighlightedCode] =
     useState<HighlightResult<F>>(null);
+
+  // This hook owns the line-number/highlight output, so it also owns the
+  // corresponding styles. The primitive boolean limits effect reruns.
+  useFeatureStyles(
+    Boolean(
+      options.showLineNumbers || options.highlightLineNumbers?.length
+    )
+  );
 
   const stableLang = useStableValue(lang);
   const stableTheme = useStableValue(themeInput);

--- a/package/src/lib/styles.ts
+++ b/package/src/lib/styles.ts
@@ -1,0 +1,40 @@
+import componentCss from '../styles/component.css?inline';
+import featuresCss from '../styles/features.css?inline';
+import * as React from 'react';
+// Side-effect import so tsdown emits dist/style.css for the ./css export;
+// stripped from the built JS, guarded by check:package
+import '../styles/index.css';
+
+const injected = new Set<string>();
+const useStyleInsertionEffect =
+  React.useInsertionEffect ?? React.useLayoutEffect;
+
+const inject = (css: string, key: string) => {
+  if (injected.has(key) || typeof document === 'undefined') return;
+  injected.add(key);
+  try {
+    // Not governed by CSP style-src in current browsers, unlike the <style> fallback
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(css);
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+  } catch {
+    const style = document.createElement('style');
+    style.dataset.reactShiki = key;
+    style.textContent = css;
+    document.head.append(style);
+  }
+};
+
+/** Installs component styles before layout without triggering a render. */
+export const useComponentStyles = () => {
+  useStyleInsertionEffect(() => {
+    inject(componentCss, 'component');
+  }, []);
+};
+
+/** Installs line-number/highlight styles only when those options are used. */
+export const useFeatureStyles = (enabled: boolean) => {
+  useStyleInsertionEffect(() => {
+    if (enabled) inject(featuresCss, 'features');
+  }, [enabled]);
+};

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -67,7 +67,6 @@ export const useShikiHighlighter: UseShikiHighlighter = (
  * ShikiHighlighter component using the web bundle.
  * Includes web-focused languages for balanced size and functionality.
  */
-export const ShikiHighlighter = createShikiHighlighterComponent(
-  useShikiHighlighter
-);
+export const ShikiHighlighter =
+  /*#__PURE__*/ createShikiHighlighterComponent(useShikiHighlighter);
 export default ShikiHighlighter;

--- a/package/tests/styles.test.ts
+++ b/package/tests/styles.test.ts
@@ -1,19 +1,83 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { UseShikiHighlighter } from '../src/lib/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  HighlighterOptions,
+  UseShikiHighlighter,
+} from '../src/lib/types';
 
 const noopHook = (() => null) as UseShikiHighlighter;
 
-// Injection runs once per module, so each test imports a fresh copy
-const importFreshFactory = async () => {
+// Enough of a highlighter for useHighlight's effect to settle quietly
+const fakeHighlighter = {
+  codeToHast: () => ({ type: 'root', children: [] }),
+  codeToHtml: () => '',
+  codeToTokens: () => ({ tokens: [] }),
+  getLoadedLanguages: () => ['text'],
+  loadLanguage: async () => {},
+} as unknown as NonNullable<HighlighterOptions['highlighter']>;
+
+const fakeFactory = async () => fakeHighlighter;
+
+interface FakeSheet {
+  cssText: string;
+}
+
+let cleanupRtl: (() => void) | undefined;
+
+// Injection state and React must come from one fresh registry per test:
+// the dedupe Set is module-level, and mixing React copies breaks hooks
+const importFresh = async () => {
   vi.resetModules();
-  const { createShikiHighlighterComponent } = await import(
-    '../src/lib/component'
-  );
-  return createShikiHighlighterComponent;
+  const [component, hook, rtl, react] = await Promise.all([
+    import('../src/lib/component'),
+    import('../src/lib/hook'),
+    import('@testing-library/react'),
+    import('react'),
+  ]);
+  cleanupRtl = rtl.cleanup;
+  return {
+    createComponent: component.createShikiHighlighterComponent,
+    useHighlight: hook.useHighlight,
+    render: rtl.render,
+    renderHook: rtl.renderHook,
+    act: rtl.act,
+    h: react.createElement,
+  };
 };
 
-describe('style injection', () => {
-  beforeEach(() => {
+const stubConstructableSheets = () => {
+  vi.stubGlobal(
+    'CSSStyleSheet',
+    class {
+      cssText = '';
+      replaceSync(css: string) {
+        this.cssText = css;
+      }
+    }
+  );
+  Object.defineProperty(document, 'adoptedStyleSheets', {
+    value: [],
+    writable: true,
+    configurable: true,
+  });
+};
+
+const stubFailingSheets = () => {
+  vi.stubGlobal(
+    'CSSStyleSheet',
+    class {
+      constructor() {
+        throw new TypeError('Illegal constructor');
+      }
+    }
+  );
+};
+
+const adoptedSheets = () =>
+  document.adoptedStyleSheets as unknown as FakeSheet[];
+
+describe('scoped style injection', () => {
+  afterEach(() => {
+    cleanupRtl?.();
     vi.unstubAllGlobals();
     for (const el of document.querySelectorAll(
       'style[data-react-shiki]'
@@ -23,64 +87,161 @@ describe('style injection', () => {
     Reflect.deleteProperty(document, 'adoptedStyleSheets');
   });
 
-  it('adopts a constructable stylesheet when supported', async () => {
-    const replaceSync = vi.fn();
-    vi.stubGlobal(
-      'CSSStyleSheet',
-      class {
-        replaceSync = replaceSync;
-      }
-    );
-    Object.defineProperty(document, 'adoptedStyleSheets', {
-      value: [],
-      writable: true,
-      configurable: true,
-    });
+  it('injects component styles on first mount without an extra render', async () => {
+    stubConstructableSheets();
+    const { createComponent, render, h } = await importFresh();
 
-    const createComponent = await importFreshFactory();
-    createComponent(noopHook);
+    const hook = vi.fn(noopHook);
+    const Component = createComponent(hook);
+    expect(adoptedSheets()).toHaveLength(0);
 
-    expect(document.adoptedStyleSheets).toHaveLength(1);
-    expect(replaceSync).toHaveBeenCalledWith(
-      expect.stringContaining('.rs-root')
+    render(h(Component, { language: 'ts', theme: 'github-dark' }, 'x'));
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(adoptedSheets()).toHaveLength(1);
+    expect(adoptedSheets()[0].cssText).toContain('.rs-root');
+    expect(adoptedSheets()[0].cssText).not.toContain(
+      '.rs-highlighted-line'
     );
+  });
+
+  it('leaves feature style ownership to the highlighting hook', async () => {
+    stubConstructableSheets();
+    const { createComponent, render, h } = await importFresh();
+
+    render(
+      h(
+        createComponent(noopHook),
+        { language: 'ts', theme: 'github-dark', showLineNumbers: true },
+        'x'
+      )
+    );
+
+    expect(adoptedSheets()).toHaveLength(1);
+    expect(adoptedSheets()[0].cssText).toContain('.rs-root');
+    expect(adoptedSheets()[0].cssText).not.toContain(
+      '.rs-highlighted-line'
+    );
+  });
+
+  it('hook without line features injects nothing', async () => {
+    stubConstructableSheets();
+    const { useHighlight, renderHook, act } = await importFresh();
+
+    renderHook(() =>
+      useHighlight(
+        'code',
+        'text',
+        'github-dark',
+        { highlighter: fakeHighlighter },
+        fakeFactory
+      )
+    );
+    await act(async () => {});
+
+    expect(adoptedSheets()).toHaveLength(0);
     expect(document.querySelector('style[data-react-shiki]')).toBeNull();
   });
 
-  it('falls back to a <style> element when constructable sheets fail', async () => {
-    vi.stubGlobal(
-      'CSSStyleSheet',
-      class {
-        constructor() {
-          throw new TypeError('Illegal constructor');
-        }
-      }
+  it('hook injects feature styles when line features become enabled', async () => {
+    stubConstructableSheets();
+    const { useHighlight, renderHook, act } = await importFresh();
+
+    const { rerender } = renderHook(
+      ({ showLineNumbers }) =>
+        useHighlight(
+          'code',
+          'text',
+          'github-dark',
+          { highlighter: fakeHighlighter, showLineNumbers },
+          fakeFactory
+        ),
+      { initialProps: { showLineNumbers: false } }
     );
+    await act(async () => {});
+    expect(adoptedSheets()).toHaveLength(0);
 
-    const createComponent = await importFreshFactory();
-    createComponent(noopHook);
+    rerender({ showLineNumbers: true });
+    await act(async () => {});
 
-    const style = document.querySelector('style[data-react-shiki]');
-    expect(style?.textContent).toContain('.rs-root');
-    expect(style?.textContent).toContain('.rs-highlighted-line');
+    const css = adoptedSheets().map((s) => s.cssText);
+    expect(css).toHaveLength(1);
+    expect(css[0]).toContain('.rs-highlighted-line');
+    expect(css[0]).not.toContain('.rs-root');
+
+    rerender({ showLineNumbers: true });
+    expect(adoptedSheets()).toHaveLength(1);
   });
 
-  it('injects only once across multiple factory calls', async () => {
-    vi.stubGlobal(
-      'CSSStyleSheet',
-      class {
-        constructor() {
-          throw new TypeError('Illegal constructor');
-        }
-      }
+  it('falls back to <style> elements when constructable sheets fail', async () => {
+    stubFailingSheets();
+    const { createComponent, useHighlight, render, renderHook, act, h } =
+      await importFresh();
+
+    render(
+      h(
+        createComponent(noopHook),
+        {
+          language: 'ts',
+          theme: 'github-dark',
+          highlightLineNumbers: [1],
+        },
+        'x'
+      )
     );
+    renderHook(() =>
+      useHighlight(
+        'code',
+        'text',
+        'github-dark',
+        { highlighter: fakeHighlighter, highlightLineNumbers: [1] },
+        fakeFactory
+      )
+    );
+    await act(async () => {});
 
-    const createComponent = await importFreshFactory();
-    createComponent(noopHook);
-    createComponent(noopHook);
+    const styles = [
+      ...document.querySelectorAll('style[data-react-shiki]'),
+    ];
+    expect(styles).toHaveLength(2);
+    expect(styles[0].textContent).toContain('.rs-root');
+    expect(styles[1].textContent).toContain('.rs-highlighted-line');
+  });
 
-    expect(
-      document.querySelectorAll('style[data-react-shiki]')
-    ).toHaveLength(1);
+  it('injects each sheet once across renders and instances', async () => {
+    stubConstructableSheets();
+    const { createComponent, useHighlight, render, renderHook, act, h } =
+      await importFresh();
+
+    const Component = createComponent(noopHook);
+    const props = {
+      language: 'ts',
+      theme: 'github-dark',
+      showLineNumbers: true,
+    };
+    const { rerender } = render(h(Component, props, 'x'));
+    rerender(h(Component, props, 'y'));
+    render(h(createComponent(noopHook), props, 'z'));
+    renderHook(() =>
+      useHighlight(
+        'code',
+        'text',
+        'github-dark',
+        { highlighter: fakeHighlighter, showLineNumbers: true },
+        fakeFactory
+      )
+    );
+    renderHook(() =>
+      useHighlight(
+        'more code',
+        'text',
+        'github-dark',
+        { highlighter: fakeHighlighter, showLineNumbers: true },
+        fakeFactory
+      )
+    );
+    await act(async () => {});
+
+    expect(adoptedSheets()).toHaveLength(2);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      rolldown:
+        specifier: ^1.2.0
+        version: 1.2.0
       tsdown:
         specifier: ^0.22.9
         version: 0.22.9(@arethetypeswrong/core@0.18.4)(@tsdown/css@0.22.9)(publint@0.3.21)(typescript@6.0.3)(unrun@0.2.37)
@@ -5980,7 +5983,7 @@ snapshots:
   vite@8.1.3(@types/node@25.9.4)(esbuild@0.27.3)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.16
       rolldown: 1.1.4
       tinyglobby: 0.2.17


### PR DESCRIPTION
Stacked on #188. That PR restores automatic style injection; this one scopes it so consumers only carry and install the CSS they actually use.

## What changes

| consumer | ships in bundle | installed |
|---|---|---|
| `<ShikiHighlighter>` | component + feature CSS | component CSS before layout on first mount; feature CSS when line options are enabled |
| hook with `showLineNumbers`/`highlightLineNumbers` | feature CSS | feature CSS before layout when the options become enabled |
| hook, no line features | feature CSS string only (~1kB, runtime-conditional so not statically removable) | nothing |

## How

- Style installation uses `useInsertionEffect` on React 18+ and `useLayoutEffect` on React 16/17, with no state updates or extra renders
- The component owns only component CSS; the shared `useHighlight` hook exclusively owns the line-number/highlight CSS it produces
- Installation remains idempotent and keyed per sheet
- The three entry factory calls are `/*#__PURE__*/`-annotated, so hook-only bundles tree-shake the entire component including its CSS
- `check:package` proves both tree-shaking directions by bundling `dist/index.mjs` with rolldown as a consumer; its generated entry paths are portable across POSIX and Windows
- The full external stylesheet remains available as `react-shiki/css` for build-time CSS pipelines or as a separately loaded fallback; importing it does not disable automatic runtime injection

## Verification

- 111/111 tests, including both injection mechanisms, hook-only feature ownership, false→true feature enablement, no style-driven component rerender, and cross-instance dedupe
- `check:package` consumer tree-shaking proof passes
- Plain Node ESM package imports pass
- Playground production build passes
- tsc, Biome, attw, and publint pass; zero sourcemap warnings