### PR TITLE
fix: remove hardcoded id from language label

### DIFF
--- a/.changeset/remove-language-label-id.md
+++ b/.changeset/remove-language-label-id.md
@@ -1,0 +1,5 @@
+---
+"react-shiki": patch
+---
+
+Fix: removed the hardcoded `id="language-label"` from the language label. Pages with multiple code blocks rendered duplicate ids (invalid HTML, and `getElementById` only ever found the first label). Style the label with the `.rs-language-label` class or `[data-slot="language-label"]` instead of `#language-label`.

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -198,7 +198,6 @@ export const createShikiHighlighterComponent = (
         >
           {showLanguage && displayLanguageId ? (
             <span
-              id="language-label"
               data-slot="language-label"
               className={clsx('rs-language-label', langClassName)}
               style={langStyle}

--- a/package/tests/component.test.tsx
+++ b/package/tests/component.test.tsx
@@ -70,7 +70,8 @@ describe('ShikiHighlighter Component', () => {
 
         expect(langLabel).toBeInTheDocument();
         expect(langLabel?.textContent).toBe('javascript');
-        expect(langLabel?.id).toBe('language-label');
+        // No id: multiple code blocks would otherwise produce duplicate ids
+        expect(langLabel?.id).toBe('');
       });
     });
 


### PR DESCRIPTION
## Summary

The language label rendered a hardcoded `id="language-label"` on every instance. Any page with two or more code blocks (the normal case for markdown content) produced duplicate ids: invalid HTML, and `getElementById('language-label')` only ever matched the first label on the page.

This removes the id. The documented styling hooks are unchanged and remain the right way to target the label:

- `.rs-language-label` class
- `[data-slot="language-label"]` attribute

## Breaking surface

Narrow and undocumented: only user CSS written against `#language-label` is affected (migrate to `.rs-language-label`). The id was never mentioned in the README or docs, and the package's own CSS targets the class. JS lookups via the id were already unreliable with multiple blocks.

`useId` was considered and rejected: nothing consumes the label's id, and per-instance generated ids can't be targeted by user CSS anyway. If ARIA labeling (`aria-labelledby` + a container role) is wanted later, that's a deliberate a11y design for a minor release.

## Changes

- `package/src/lib/component.tsx` — drop the `id` attribute from the label span
- `package/tests/component.test.tsx` — assert the label has no id
- changeset (patch) with migration note