### PR TITLE
refactor: simplify internals

### DIFF
--- a/package/src/bundles/factory.ts
+++ b/package/src/bundles/factory.ts
@@ -1,0 +1,34 @@
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
+import type {
+  Awaitable,
+  DynamicImportLanguageRegistration,
+  HighlighterCore,
+  RegexEngine,
+} from 'shiki/core';
+import type { HighlighterFactory, Language, Theme } from '../lib/types';
+import { isLoadableLanguage } from '../lib/language';
+
+type GetSingletonHighlighter = (options: {
+  langs: NonNullable<Language>[];
+  themes: Theme[];
+  engine: Awaitable<RegexEngine>;
+}) => Promise<HighlighterCore>;
+
+/**
+ * Builds a highlighter factory for a Shiki bundle (full or web).
+ * Unloadable languages are filtered out so unknown ids fall back to
+ * plaintext instead of throwing.
+ */
+export const bundledHighlighterFactory =
+  (
+    getSingletonHighlighter: GetSingletonHighlighter,
+    bundledLanguages: Record<string, DynamicImportLanguageRegistration>
+  ): HighlighterFactory =>
+  (langsToLoad, themesToLoad, engine) =>
+    getSingletonHighlighter({
+      langs: langsToLoad.filter((lang) =>
+        isLoadableLanguage(lang, bundledLanguages)
+      ),
+      themes: themesToLoad,
+      engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
+    });

--- a/package/src/bundles/full.ts
+++ b/package/src/bundles/full.ts
@@ -1,30 +1,11 @@
-import {
-  getSingletonHighlighter,
-  bundledLanguages,
-  type Highlighter,
-  type Awaitable,
-  type RegexEngine,
-} from 'shiki';
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
-import type { Language, Theme } from '../lib/types';
-import { isLoadableLanguage } from '../lib/language';
+import { getSingletonHighlighter, bundledLanguages } from 'shiki';
+import { bundledHighlighterFactory } from './factory';
 
 /**
- * Creates a highlighter using the full Shiki bundle with all languages and themes.
- * This is the largest bundle but provides maximum compatibility.
+ * Highlighter factory for the full Shiki bundle: every language and
+ * theme, largest size, maximum compatibility.
  */
-export async function createFullHighlighter(
-  langsToLoad: Language[],
-  themesToLoad: Theme[],
-  engine?: Awaitable<RegexEngine>
-): Promise<Highlighter> {
-  const langs = langsToLoad.filter((lang) =>
-    isLoadableLanguage(lang, bundledLanguages)
-  );
-
-  return await getSingletonHighlighter({
-    langs,
-    themes: themesToLoad,
-    engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
-  });
-}
+export const createFullHighlighter = bundledHighlighterFactory(
+  getSingletonHighlighter,
+  bundledLanguages
+);

--- a/package/src/bundles/web.ts
+++ b/package/src/bundles/web.ts
@@ -1,31 +1,15 @@
 import {
   getSingletonHighlighter,
   bundledLanguages,
-  type Highlighter,
-  type Awaitable,
-  type RegexEngine,
 } from 'shiki/bundle/web';
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
-import type { Language, Theme } from '../lib/types';
-import { isLoadableLanguage } from '../lib/language';
+import { bundledHighlighterFactory } from './factory';
 
 /**
- * Creates a highlighter using the web Shiki bundle with web-focused languages.
- * Smaller than the full bundle while covering most web development needs.
- * Includes: HTML, CSS, JS, TS, JSON, Markdown, Vue, JSX, Svelte, etc.
+ * Highlighter factory for the web Shiki bundle: web-focused languages
+ * (HTML, CSS, JS, TS, JSON, Markdown, Vue, JSX, Svelte, etc.) at a
+ * fraction of the full bundle's size.
  */
-export async function createWebHighlighter(
-  langsToLoad: Language[],
-  themesToLoad: Theme[],
-  engine?: Awaitable<RegexEngine>
-): Promise<Highlighter> {
-  const langs = langsToLoad.filter((lang) =>
-    isLoadableLanguage(lang, bundledLanguages)
-  );
-
-  return await getSingletonHighlighter({
-    langs,
-    themes: themesToLoad,
-    engine: engine ?? createOnigurumaEngine(import('shiki/wasm')),
-  });
-}
+export const createWebHighlighter = bundledHighlighterFactory(
+  getSingletonHighlighter,
+  bundledLanguages
+);

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -71,7 +71,6 @@ export const useShikiHighlighter: UseShikiHighlighter = (
   themeInput,
   options = {}
 ) => {
-  // Validate that highlighter is provided
   const highlighter = validateCoreHighlighter(options.highlighter);
 
   return useHighlight(

--- a/package/src/lib/component.tsx
+++ b/package/src/lib/component.tsx
@@ -96,23 +96,6 @@ export interface ShikiHighlighterProps extends HighlighterOptions {
   showLanguage?: boolean;
 
   /**
-   * Whether to show line numbers
-   * @default false
-   */
-  showLineNumbers?: boolean;
-
-  /**
-   * Starting line number (when showLineNumbers is true)
-   * @default 1
-   */
-  startingLineNumber?: number;
-
-  /**
-   * Displayed line numbers to highlight
-   */
-  highlightLineNumbers?: number[];
-
-  /**
    * The HTML element that wraps the generated code block.
    * @default 'div'
    */
@@ -131,45 +114,22 @@ export const createShikiHighlighterComponent = (
       {
         language,
         theme,
-        delay,
-        transformers,
-        defaultColor,
-        cssVariablePrefix,
         addDefaultStyles = true,
         style,
         langStyle,
         className,
         langClassName,
         showLanguage = true,
-        showLineNumbers = false,
-        startingLineNumber = 1,
-        highlightLineNumbers,
         children: code,
         as: Element = 'div',
-        customLanguages,
-        preloadLanguages,
         outputFormat,
-        ...shikiOptions
+        ...options
       },
       ref
     ) => {
       // Kept inside the component so hook-only bundles can tree-shake it
       // together with the component CSS.
       useComponentStyles();
-
-      const options: HighlighterOptions = {
-        delay,
-        transformers,
-        customLanguages,
-        preloadLanguages,
-        showLineNumbers,
-        defaultColor,
-        cssVariablePrefix,
-        startingLineNumber,
-        highlightLineNumbers,
-        outputFormat: resolveOutputFormat(outputFormat),
-        ...shikiOptions,
-      };
 
       const displayLanguageId =
         typeof language === 'object'
@@ -180,7 +140,10 @@ export const createShikiHighlighterComponent = (
         code,
         language,
         theme,
-        options
+        {
+          ...options,
+          outputFormat: resolveOutputFormat(outputFormat),
+        }
       );
 
       return (

--- a/package/src/lib/language.ts
+++ b/package/src/lib/language.ts
@@ -81,6 +81,20 @@ export const resolveLoadedLanguage = (
     : FALLBACK_LANGUAGE;
 
 /**
+ * A registration matches a query by name, scopeName (full or its last
+ * segment, e.g. "source.tsx" -> "tsx"), aliases, or fileTypes.
+ */
+const registrationMatches = (
+  candidate: LanguageRegistration,
+  matches: (str: string | undefined) => boolean
+): boolean =>
+  matches(candidate.name) ||
+  matches(candidate.scopeName) ||
+  matches(candidate.scopeName?.split('.').pop()) ||
+  !!candidate.aliases?.some(matches) ||
+  !!candidate.fileTypes?.some(matches);
+
+/**
  * Resolves the language input to standardized IDs and objects for Shiki
  * @param lang The language input from props
  * @param customLanguages An array of custom textmate grammar objects or a single grammar object
@@ -96,69 +110,50 @@ export const resolveLanguage = (
 ): LanguageResult => {
   const customLangs = toArray(customLanguages);
   const preloadLangs = toArray(preloadLanguages);
-  const customMatchPool = [...customLangs, ...preloadLangs];
-  let languageId = FALLBACK_LANGUAGE;
-  let primaryLang: Language;
 
-  // Language is null or empty string
-  if (lang == null || (typeof lang === 'string' && !lang.trim())) {
-    return {
-      languageId,
-      langsToLoad: dedupeLanguages([...preloadLangs, ...customLangs]),
-    };
-  }
-
-  // Language is custom object
-  if (typeof lang === 'object') {
-    languageId = lang.name;
-    primaryLang = lang;
-  } else {
-    // Language is string
-    const normalizedLang = lang.trim();
-    const lowerLang = normalizedLang.toLowerCase();
-    const matches = (str: string | undefined): boolean =>
-      str?.toLowerCase() === lowerLang;
-
-    // Check custom registrations (from both customLanguages and preloadLanguages)
-    const customMatch = customMatchPool.find(
-      (candidate): candidate is LanguageRegistration =>
-        typeof candidate === 'object' &&
-        candidate != null &&
-        !!(
-          matches(candidate.name) ||
-          matches(candidate.scopeName) ||
-          matches(candidate.scopeName?.split('.').pop()) ||
-          candidate.aliases?.some(matches) ||
-          candidate.fileTypes?.some(matches)
-        )
-    );
-
-    if (customMatch) {
-      languageId = customMatch.name || normalizedLang;
-      primaryLang = customMatch;
-    } else {
-      const alias = Object.entries(langAliases ?? {}).find(([name]) =>
-        matches(name)
-      )?.[1];
-
-      if (alias) {
-        // Language is aliased
-        languageId = alias;
-        primaryLang = alias;
-      } else {
-        // For any other string, pass it through to the factory
-        languageId = normalizedLang;
-        primaryLang = normalizedLang;
-      }
-    }
-  }
-
-  return {
+  const result = (
+    languageId: string,
+    primary?: Language
+  ): LanguageResult => ({
     languageId,
     langsToLoad: dedupeLanguages([
-      primaryLang,
+      primary,
       ...preloadLangs,
       ...customLangs,
     ]),
-  };
+  });
+
+  if (lang == null || (typeof lang === 'string' && !lang.trim())) {
+    return result(FALLBACK_LANGUAGE);
+  }
+
+  if (typeof lang === 'object') {
+    return result(lang.name, lang);
+  }
+
+  const normalized = lang.trim();
+  const query = normalized.toLowerCase();
+  const matches = (str: string | undefined): boolean =>
+    str?.toLowerCase() === query;
+
+  // Custom registrations (from both customLanguages and preloadLanguages)
+  const customMatch = [...customLangs, ...preloadLangs].find(
+    (candidate): candidate is LanguageRegistration =>
+      typeof candidate === 'object' &&
+      candidate != null &&
+      registrationMatches(candidate, matches)
+  );
+  if (customMatch) {
+    return result(customMatch.name || normalized, customMatch);
+  }
+
+  const alias = Object.entries(langAliases ?? {}).find(([name]) =>
+    matches(name)
+  )?.[1];
+  if (alias) {
+    return result(alias, alias);
+  }
+
+  // Any other string passes through to the factory
+  return result(normalized, normalized);
 };

--- a/package/src/lib/transformers.ts
+++ b/package/src/lib/transformers.ts
@@ -13,13 +13,12 @@ export function lineNumbersTransformer(startLine = 1): ShikiTransformer {
     code(node) {
       this.addClassToHast(node, 'rs-has-line-numbers');
       if (startLine !== 1) {
-        const existingStyle = (node.properties?.style as string) || '';
-        const newStyle = existingStyle
-          ? `${existingStyle}; --line-start: ${startLine}`
-          : `--line-start: ${startLine}`;
+        const existing = node.properties?.style as string | undefined;
         node.properties = {
           ...node.properties,
-          style: newStyle,
+          style: [existing, `--line-start: ${startLine}`]
+            .filter(Boolean)
+            .join('; '),
         };
       }
     },

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -58,9 +58,7 @@ type Theme = ThemeRegistrationAny | StringLiteralUnion<BundledTheme>;
  *
  * @see https://shiki.style/guide/dual-themes
  */
-type Themes = {
-  [Key in MultiThemeKey]: Theme;
-};
+type Themes = Record<MultiThemeKey, Theme>;
 
 /**
  * Configuration options specific to react-shiki


### PR DESCRIPTION
Behavior-preserving cleanup. No changeset needed, will ride with other changes onto 0.11.1

- **component.tsx** — destructure only display props and spread the rest through to the hook, instead of re-listing every highlighter option. Drops redundant defaults and prop declarations already inherited from `ReactShikiOptions`.
- **language.ts** — rewrite `resolveLanguage` with early returns per input case; extract the match predicate as `registrationMatches`.
- **bundles/** — `full.ts` and `web.ts` differed only by import source; both now derive from a shared `bundledHighlighterFactory`. Bundle separation is unaffected (each entry still imports only its own shiki bundle and passes it in).
- Minor: simplify transformer style merge, `Themes` as `Record`, prune a redundant comment.

Public type surface verified unchanged: built `.d.mts` diff is limited to the two equivalent type rewrites, confirmed identical via strict type-identity tests. `pnpm check`, tests (111), and build (attw + publint) all clean.