### PR TITLE
feat: accept 'javascript' and 'oniguruma' as named engines

### DIFF
--- a/.changeset/named-engines.md
+++ b/.changeset/named-engines.md
@@ -8,4 +8,4 @@ Add named engines: `engine` now accepts `'javascript'` or `'oniguruma'` alongsid
 - Referentially stable, so safe to pass inline without re-triggering highlighting on rerenders
 - Engine instances are still accepted for custom configuration; create them once at module scope
 
-**Heads up:** the next minor release, **0.12**, will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).
+**Heads up:** the next minor release will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).

--- a/.changeset/named-engines.md
+++ b/.changeset/named-engines.md
@@ -1,0 +1,11 @@
+---
+"react-shiki": patch
+---
+
+Add named engines: `engine` now accepts `'javascript'` or `'oniguruma'` alongside engine instances.
+
+- Named engines are created, cached, and lazy-loaded internally; `'javascript'` skips the WASM fetch entirely
+- Referentially stable, so safe to pass inline without re-triggering highlighting on rerenders
+- Engine instances are still accepted for custom configuration; create them once at module scope
+
+**Heads up:** the next minor release, **0.12**, will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).

--- a/package/README.md
+++ b/package/README.md
@@ -149,29 +149,54 @@ Shiki offers three built-in engines for syntax highlighting:
 
 #### Using Engines with Full and Web Bundles
 
-The full and web bundles use Oniguruma by default, but you can override this with the `engine` option:
+The full and web bundles use Oniguruma by default. The easiest way to switch is a named engine, which react-shiki creates and caches internally. No imports, no WASM fetch with `'javascript'`, and it's safe to pass inline:
 
 ```tsx
-import {
-  useShikiHighlighter,
-  createJavaScriptRegexEngine,
-  createJavaScriptRawEngine
-} from 'react-shiki';
-
-// Hook with JavaScript RegExp engine
+// Hook
 const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
-  engine: createJavaScriptRegexEngine()
+  engine: 'javascript'
 });
 
-// Component with JavaScript Raw engine (for pre-compiled languages)
-// See https://shiki.style/guide/regex-engines#pre-compiled-languages
-<ShikiHighlighter
-  language="typescript"
-  theme="github-dark"
-  engine={createJavaScriptRawEngine()}
->
+// Component
+<ShikiHighlighter language="typescript" theme="github-dark" engine="javascript">
   {code}
 </ShikiHighlighter>
+```
+
+> [!NOTE]
+> The underlying highlighter is a singleton created on the first highlight, so pass the same engine at every call site; mixed engines resolve to whichever highlighted first.
+>
+> **Heads up:** the next minor release, **0.12**, will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).
+
+For engine configuration beyond the named defaults, pass an engine instance. **Create it once at module scope.** A new instance on every render defeats memoization and re-triggers highlighting on each render:
+
+```tsx
+import { useShikiHighlighter, createJavaScriptRegexEngine } from 'react-shiki';
+
+// Module scope: created once, stable across renders
+const engine = createJavaScriptRegexEngine({ forgiving: true });
+
+const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
+  engine
+});
+```
+
+The JavaScript Raw engine works the same way, but only with [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages) (`@shikijs/langs-precompiled`). The full and web bundles ship regular grammars, so use it with the core bundle and a custom highlighter:
+
+```tsx
+import { useShikiHighlighter, createJavaScriptRawEngine } from 'react-shiki/core';
+import { createHighlighterCore } from 'react-shiki/core';
+
+// Module scope: raw engine + pre-compiled grammars, smallest and fastest
+const highlighter = await createHighlighterCore({
+  themes: [import('@shikijs/themes/github-dark')],
+  langs: [import('@shikijs/langs-precompiled/typescript')],
+  engine: createJavaScriptRawEngine()
+});
+
+const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
+  highlighter
+});
 ```
 
 #### Using Engines with Core Bundle
@@ -215,7 +240,7 @@ See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more i
 | `customLanguages`   | `array`            | `[]`            | **Deprecated**: use `preloadLanguages` instead. |
 | `preloadLanguages`  | `array`            | `[]`            | Preload bundled language IDs and custom language grammars |
 | `langAlias`         | `object`           | `{}`            | Map of language aliases                                                       |
-| `engine`            | `RegexEngine`      | Oniguruma       | RegExp engine for syntax highlighting (Oniguruma, JavaScript RegExp, or JavaScript Raw) |
+| `engine`            | `'javascript' \| 'oniguruma' \| RegexEngine` | `'oniguruma'` | RegExp engine for syntax highlighting; named engines are created and cached internally |
 | `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
 | `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
 | `highlightLineNumbers` | `number[]`     | -               | Displayed line numbers to highlight                                           |

--- a/package/README.md
+++ b/package/README.md
@@ -143,9 +143,14 @@ const highlighter = await createHighlighterCore({
 ### RegExp Engines
 
 Shiki offers three built-in engines for syntax highlighting:
-- **Oniguruma** - Default engine using compiled WebAssembly, offers maximum language support
-- **JavaScript RegExp** - Smaller bundle, faster startup, compiles patterns on-the-fly, recommended for client-side highlighting
-- **JavaScript Raw** - For [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages), skips transpilation step for best performance
+
+| Engine | Payload (gzip) | Startup | Grammar support |
+| --- | --- | --- | --- |
+| **Oniguruma** (default) | ~150 KB (466 KB WASM) | fetch + compile WASM | Reference engine, all grammars |
+| **JavaScript RegExp** | ~20 KB | none, plain JS | All built-in languages ([compatibility table](https://shiki.style/references/engine-js-compat)); [strict by default](https://shiki.style/guide/regex-engines#use-with-unsupported-languages) |
+| **JavaScript Raw** | ~1 KB | none | [Pre-compiled grammars](https://shiki.style/guide/regex-engines#pre-compiled-languages) only, has a [known bug](https://github.com/shikijs/shiki/issues/918) |
+
+Payload sizes measured against shiki 4.3.0: `onig.wasm` is 466 KB (149 KB gzipped), the JavaScript engine's pattern transpiler ([oniguruma-to-es](https://github.com/slevithan/oniguruma-to-es)) is 57 KB (20 KB gzipped), and the raw engine skips the transpiler entirely. Beyond the smaller download, the JavaScript engine also starts instantly (no WASM fetch and compile) and [runs patterns as native JavaScript RegExp](https://shiki.style/guide/regex-engines#javascript-regexp-engine), which is faster for some languages.
 
 #### Using Engines with Full and Web Bundles
 
@@ -202,9 +207,12 @@ const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
 });
 ```
 
+> [!WARNING]
+> Pre-compiled grammars have a [known upstream bug](https://github.com/shikijs/shiki/issues/918): some languages highlight incorrectly (Python, HTML, Perl, and YAML among those reported). Verify your languages render correctly before shipping, or use `createJavaScriptRegexEngine` with regular grammars.
+
 #### Using Engines with Core Bundle
 
-When using the core bundle, you must specify an engine:
+Named engines don't apply to the core bundle: react-shiki never creates the highlighter there, you build it yourself, and shiki's `createHighlighterCore` requires an engine instance. Creating it at module scope alongside the highlighter is the correct pattern:
 
 ```tsx
 import {

--- a/package/README.md
+++ b/package/README.md
@@ -184,8 +184,11 @@ const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
 The JavaScript Raw engine works the same way, but only with [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages) (`@shikijs/langs-precompiled`). The full and web bundles ship regular grammars, so use it with the core bundle and a custom highlighter:
 
 ```tsx
-import { useShikiHighlighter, createJavaScriptRawEngine } from 'react-shiki/core';
-import { createHighlighterCore } from 'react-shiki/core';
+import {
+  useShikiHighlighter,
+  createHighlighterCore,
+  createJavaScriptRawEngine,
+} from 'react-shiki/core';
 
 // Module scope: raw engine + pre-compiled grammars, smallest and fastest
 const highlighter = await createHighlighterCore({

--- a/package/README.md
+++ b/package/README.md
@@ -2,10 +2,8 @@
 
 A performant client-side syntax highlighting component and hook for React, built with [Shiki](https://shiki.matsu.io/).
 
-[See the demo page with highlighted code blocks showcasing several Shiki themes!](https://react-shiki.vercel.app/)
-
 <!--toc:start-->
-- [🎨 react-shiki](#🎨-react-shiki)
+- [🎨 react-shiki](#-react-shiki)
   - [Features](#features)
   - [Installation](#installation)
   - [Usage](#usage)
@@ -14,11 +12,14 @@ A performant client-side syntax highlighting component and hook for React, built
     - [`react-shiki/web` (Web Bundle)](#react-shikiweb-web-bundle)
     - [`react-shiki/core` (Minimal Bundle)](#react-shikicore-minimal-bundle)
     - [RegExp Engines](#regexp-engines)
-      - [Using Engines with Full and Web Bundles](#using-engines-with-full-and-web-bundles)
-      - [Using Engines with Core Bundle](#using-engines-with-core-bundle)
-      - [Engine Options](#engine-options)
+      - [Full and Web Bundles](#full-and-web-bundles)
+      - [Custom Highlighters (Core Bundle)](#custom-highlighters-core-bundle)
+        - [JavaScript Raw Engine](#javascript-raw-engine)
+  - [Output Formats](#output-formats)
   - [Configuration](#configuration)
     - [Common Configuration Options](#common-configuration-options)
+      - [react-shiki Options](#react-shiki-options)
+      - [Shiki Pass-through Options](#shiki-pass-through-options)
     - [Component-specific Props](#component-specific-props)
     - [Embedded Language Highlighting](#embedded-language-highlighting)
     - [Multi-theme Support](#multi-theme-support)
@@ -36,7 +37,6 @@ A performant client-side syntax highlighting component and hook for React, built
     - [Handling Inline Code](#handling-inline-code)
   - [Performance](#performance)
     - [Throttling Real-time Highlighting](#throttling-real-time-highlighting)
-    - [Output Formats](#output-formats)
 <!--toc:end-->
 
 ## Features
@@ -98,8 +98,8 @@ function CodeBlock({ code, language }) {
 ```tsx
 import ShikiHighlighter from 'react-shiki';
 ```
-- **Size**: ~6.4MB minified, ~1.2MB gzipped (includes ~12KB react-shiki)
-- **Languages**: All Shiki languages and themes
+- **Size**: ~6.4MB minified, ~1.2MB gzipped (react-shiki itself: ~9KB minified, ~4KB gzipped)
+- **Languages**: All Shiki [languages](https://shiki.style/languages) and [themes](https://shiki.style/themes)
 - **Exported engines**: `createJavaScriptRegexEngine`, `createJavaScriptRawEngine`
 - **Use case**: Unknown language requirements, maximum language support
 - **Setup**: Zero configuration required
@@ -108,8 +108,8 @@ import ShikiHighlighter from 'react-shiki';
 ```tsx
 import ShikiHighlighter from 'react-shiki/web';
 ```
-- **Size**: ~3.8MB minified, ~707KB gzipped (includes ~12KB react-shiki)
-- **Languages**: Web-focused languages (HTML, CSS, JS, TS, JSON, Markdown, Vue, JSX, Svelte)
+- **Size**: ~3.8MB minified, ~707KB gzipped (react-shiki itself: ~9KB minified, ~4KB gzipped)
+- **Languages**: [Web-focused languages](https://shiki.style/guide/bundles#shiki-bundle-web) (HTML, CSS, JS, TS, JSON, Markdown, Vue, JSX, Svelte)
 - **Exported engines**: `createJavaScriptRegexEngine`, `createJavaScriptRawEngine`
 - **Use case**: Web applications with balanced size/functionality
 - **Setup**: Drop-in replacement for main entry point
@@ -134,7 +134,7 @@ const highlighter = await createHighlighterCore({
   {code}
 </ShikiHighlighter>
 ```
-- **Size**: ~12KB + your imported themes/languages
+- **Size**: ~9KB minified (~4KB gzipped) + your imported themes/languages
 - **Languages**: User-defined via custom highlighter  
 - **Use case**: Production apps requiring maximum bundle control
 - **Setup**: Requires custom highlighter configuration
@@ -147,14 +147,14 @@ Shiki offers three built-in engines for syntax highlighting:
 | Engine | Payload (gzip) | Startup | Grammar support |
 | --- | --- | --- | --- |
 | **Oniguruma** (default) | ~150 KB (466 KB WASM) | fetch + compile WASM | Reference engine, all grammars |
-| **JavaScript RegExp** | ~20 KB | none, plain JS | All built-in languages ([compatibility table](https://shiki.style/references/engine-js-compat)); [strict by default](https://shiki.style/guide/regex-engines#use-with-unsupported-languages) |
+| **JavaScript RegExp** | ~20 KB | none, plain JS | All built-in languages ([compatibility table](https://shiki.style/references/engine-js-compat)); [strict by default](#full-and-web-bundles) |
 | **JavaScript Raw** | ~1 KB | none | [Pre-compiled grammars](https://shiki.style/guide/regex-engines#pre-compiled-languages) only, has a [known bug](https://github.com/shikijs/shiki/issues/918) |
 
 Payload sizes measured against shiki 4.3.0: `onig.wasm` is 466 KB (149 KB gzipped), the JavaScript engine's pattern transpiler ([oniguruma-to-es](https://github.com/slevithan/oniguruma-to-es)) is 57 KB (20 KB gzipped), and the raw engine skips the transpiler entirely. Beyond the smaller download, the JavaScript engine also starts instantly (no WASM fetch and compile) and [runs patterns as native JavaScript RegExp](https://shiki.style/guide/regex-engines#javascript-regexp-engine), which is faster for some languages.
 
-#### Using Engines with Full and Web Bundles
+#### Full and Web Bundles
 
-The full and web bundles use Oniguruma by default. The easiest way to switch is a named engine, which react-shiki creates and caches internally. No imports, no WASM fetch with `'javascript'`, and it's safe to pass inline:
+The full and web bundles use Oniguruma by default. You can swap to the JavaScript engine by passing `'javascript'` to `engine`. react-shiki creates and caches the engine internally, no need to import it, no WASM fetch with `'javascript'`, and it's safe to pass inline:
 
 ```tsx
 // Hook
@@ -167,18 +167,16 @@ const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
   {code}
 </ShikiHighlighter>
 ```
-
+<!-- TODO: painful that we need this callout, painful engine prop on component! -->
 > [!NOTE]
-> The underlying highlighter is a singleton created on the first highlight, so pass the same engine at every call site; mixed engines resolve to whichever highlighted first.
->
-> **Heads up:** the next minor release, **0.12**, will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).
+> The underlying highlighter is a singleton created on the first highlight, so pass the same engine at every call site; mixed engines resolve to whichever highlighted first. 
 
-For engine configuration beyond the named defaults, pass an engine instance. **Create it once at module scope.** A new instance on every render defeats memoization and re-triggers highlighting on each render:
+To customize engine configuration beyond the named defaults, pass an engine instance. **Create it once at module scope**; this avoids recreating new instances on every render, which would defeat memoization:
 
 ```tsx
 import { useShikiHighlighter, createJavaScriptRegexEngine } from 'react-shiki';
 
-// Module scope: created once, stable across renders
+// Ensure this is at the module scope: created once, stable across renders
 const engine = createJavaScriptRegexEngine({ forgiving: true });
 
 const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
@@ -186,7 +184,34 @@ const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
 });
 ```
 
-The JavaScript Raw engine works the same way, but only with [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages) (`@shikijs/langs-precompiled`). The full and web bundles ship regular grammars, so use it with the core bundle and a custom highlighter:
+The JavaScript engine is strict by default: it throws when a grammar uses patterns it can't convert. `forgiving: true` skips those patterns for best-effort output. It also accepts `target` and `regexConstructor`, see [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for details.
+
+The JavaScript Raw engine works the same way, but only with [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages) (`@shikijs/langs-precompiled`). The full and web bundles don't support the raw engine because they bundle standard grammars, you need a [custom highlighter](#custom-highlighters-core-bundle).
+
+> [!IMPORTANT]
+> **Heads up:** in a future release, react-shiki's default engine will be swapped from Oniguruma WASM to the JavaScript engine (with [`forgiving`](https://shiki.style/guide/regex-engines#use-with-unsupported-languages) enabled by default).
+
+#### Custom Highlighters (Core Bundle)
+
+Named engines (`'javascript'`, `'oniguruma'`) don't apply to the core bundle since you create the highlighter with `createHighlighterCore`; instead, use `createJavaScriptRegexEngine` or `createOnigurumaEngine` to create a custom engine instance:
+
+```tsx
+import {
+  createHighlighterCore,
+  createOnigurumaEngine,
+  createJavaScriptRegexEngine
+} from 'react-shiki/core';
+
+const highlighter = await createHighlighterCore({
+  themes: [import('@shikijs/themes/nord')],
+  langs: [import('@shikijs/langs/typescript')],
+  engine: createJavaScriptRegexEngine() // or createOnigurumaEngine(import('shiki/wasm'))
+});
+```
+
+##### JavaScript Raw Engine
+
+The JavaScript Raw engine is the smallest option at only ~1 KB, but requires [pre-compiled languages](https://shiki.style/guide/regex-engines#pre-compiled-languages), and faces a known upstream bug -- [shikijs/shiki:issue#918](https://github.com/shikijs/shiki/issues/918) -- causing some languages (Python, HTML, Perl, and YAML among those reported) to highlight incorrectly.
 
 ```tsx
 import {
@@ -207,62 +232,107 @@ const highlightedCode = useShikiHighlighter(code, 'typescript', 'github-dark', {
 });
 ```
 
-> [!WARNING]
-> Pre-compiled grammars have a [known upstream bug](https://github.com/shikijs/shiki/issues/918): some languages highlight incorrectly (Python, HTML, Perl, and YAML among those reported). Verify your languages render correctly before shipping, or use `createJavaScriptRegexEngine` with regular grammars.
+Be sure to verify your language highlights correctly if you choose to use the raw engine ([shikijs/shiki:issue#918](https://github.com/shikijs/shiki/issues/918)).
 
-#### Using Engines with Core Bundle
 
-Named engines don't apply to the core bundle: react-shiki never creates the highlighter there, you build it yourself, and shiki's `createHighlighterCore` requires an engine instance. Creating it at module scope alongside the highlighter is the correct pattern:
+## Output Formats
 
+`react-shiki` can return highlighted code in three formats:
+
+**React Nodes (Default)** - Rendered as React elements, no `dangerouslySetInnerHTML` required
 ```tsx
-import {
-  createHighlighterCore,
-  createOnigurumaEngine,
-  createJavaScriptRegexEngine
-} from 'react-shiki/core';
+// Hook
+const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark");
 
-const highlighter = await createHighlighterCore({
-  themes: [import('@shikijs/themes/nord')],
-  langs: [import('@shikijs/langs/typescript')],
-  engine: createJavaScriptRegexEngine() // or createOnigurumaEngine(import('shiki/wasm'))
+// Component
+<ShikiHighlighter language="tsx" theme="github-dark">
+  {code}
+</ShikiHighlighter>
+```
+
+**HTML String** - Rendered via `dangerouslySetInnerHTML`
+```tsx
+// Hook (returns HTML string, use dangerouslySetInnerHTML to render)
+const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
+  outputFormat: 'html'
 });
+
+// Component (automatically uses dangerouslySetInnerHTML when outputFormat is 'html')
+<ShikiHighlighter language="tsx" theme="github-dark" outputFormat="html">
+  {code}
+</ShikiHighlighter>
 ```
 
-#### Engine Options
-
-The JavaScript RegExp engine is [strict by default](https://shiki.style/guide/regex-engines#use-with-unsupported-languages). For best-effort results with unsupported grammars, enable the `forgiving` option:
-
+**Shiki Tokens (Experimental)** - Hook-only output (bring your own renderer, react-shiki does not provide one)
 ```tsx
-createJavaScriptRegexEngine({ forgiving: true });
+const highlighted = useShikiHighlighter(code, "tsx", "github-dark", {
+  outputFormat: "tokens",
+});
+
+// Sample only, not a production renderer: you own rendering, memoization,
+// and commit management (critical for streaming highlighting)
+const rendered = highlighted?.tokens.map((line, i) => (
+  <div key={i}>
+    {line.map((token, j) => (
+      <span key={j} style={{ color: token.color }}>
+        {token.content}
+      </span>
+    ))}
+  </div>
+));
 ```
 
-See [Shiki - RegExp Engines](https://shiki.style/guide/regex-engines) for more info.
+The React and HTML formats spend their rendering work in different phases. HTML output skips per-token React element creation and reconciliation, reducing render-phase overhead for large, one-shot highlights, but each update replaces the code block's entire DOM subtree via `innerHTML`. React output pays for element creation and diffing on every update, but commits only incremental DOM mutations, minimizing DOM churn for frequently re-highlighted code such as streaming LLM output.
+
+HTML output hands the highlighted markup to the DOM via `dangerouslySetInnerHTML`, so only use it with trusted code sources. The default React output is the safe choice for untrusted content.
+
+Token output is for when you need to own rendering yourself; it is intentionally available on the hook, not the `ShikiHighlighter` component, since react-shiki's markup-based features no longer apply once you control the markup. Note that Shiki's `codeToTokens` does not run transformers or decorations, so markup-producing options, including transformers, decorations, line numbers, and `structure`, have no effect on token output.
 
 ## Configuration
 
 ### Common Configuration Options
 
-| Option              | Type               | Default         | Description                                                                   |
+The core inputs, positional arguments on the hook, props/children on the component:
+
+| Input               | Type               | Default         | Description                                                                   |
 | ------------------- | ------------------ | --------------- | ----------------------------------------------------------------------------- |
 | `code`            | `string`           | -               | Code to highlight                                                               |
 | `language`          | `string \| object` | -               | Language to highlight, built-in or custom TextMate grammar object             |
 | `theme`             | `string \| object` | `'github-dark'` | Single or multi-theme configuration, built-in or custom TextMate theme object |
-| `delay`             | `number`           | `0`             | Delay between highlights (in milliseconds)                                    |
-| `customLanguages`   | `array`            | `[]`            | **Deprecated**: use `preloadLanguages` instead. |
-| `preloadLanguages`  | `array`            | `[]`            | Preload bundled language IDs and custom language grammars |
-| `langAlias`         | `object`           | `{}`            | Map of language aliases                                                       |
+
+#### react-shiki Options
+
+
+| Option              | Type               | Default         | Description                                                                   |
+| ------------------- | ------------------ | --------------- | ----------------------------------------------------------------------------- |
+| `delay`             | `number`           | -               | Minimum time between highlights (in milliseconds), no throttling by default   |
 | `engine`            | `'javascript' \| 'oniguruma' \| RegexEngine` | `'oniguruma'` | RegExp engine for syntax highlighting; named engines are created and cached internally |
+| `highlighter`       | `Highlighter \| HighlighterCore` | -  | Custom highlighter instance, required for the core bundle                     |
+| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens (hook only, experimental) |
+| `preloadLanguages`  | `array`            | `[]`            | Preload bundled language IDs and custom language grammars |
+| `customLanguages`   | `array`            | `[]`            | **Deprecated**: use `preloadLanguages` instead. |
 | `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
 | `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
 | `highlightLineNumbers` | `number[]`     | -               | Displayed line numbers to highlight                                           |
-| `transformers`      | `array`            | `[]`            | Custom Shiki transformers for modifying the highlighting output               |
-| `cssVariablePrefix` | `string`           | `'--shiki'`     | Prefix for CSS variables storing theme colors                                 |
-| `defaultColor`      | `string \| false`  | `'light'`       | Default theme mode when using multiple themes, can also disable default theme |
-| `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens (hook only, experimental) |
-| `tabindex`          | `number`           | `0`             | Tab index for the code block                                                  |
-| `decorations`       | `array`            | `[]`            | Custom decorations to wrap the highlighted tokens with                        |
-| `structure`        | `string`           | `'classic'`  | The structure of the generated HAST and HTML - `classic` or `inline`               |
-| [`codeToHastOptions`](https://github.com/shikijs/shiki/blob/main/packages/types/src/options.ts#L121) | -             | -              | All other options supported by Shiki's `codeToHast`      |
+
+#### Shiki Pass-through Options
+
+All of Shiki's options pass-through and are accessible in react-shiki.
+
+Based on `outputFormat`:
+- `'tokens'`: All options supported by Shiki's [`codeToTokens`](https://github.com/shikijs/shiki/blob/v4.3.0/packages/types/src/tokens.ts#L27)
+- `'html'`: All options supported by Shiki's [`codeToHtml`](https://github.com/shikijs/shiki/blob/v4.3.0/packages/types/src/options.ts#L136)
+- `'react'`: All options supported by Shiki's [`codeToHast`](https://github.com/shikijs/shiki/blob/v4.3.0/packages/types/src/options.ts#L136)
+
+Commonly used:
+- `transformers`: modify the highlighting output with Shiki transformers (default: `[]`)
+- `decorations`: wrap ranges of highlighted tokens (default: `[]`)
+- `defaultColor`: default theme mode with multi-theme, `false` to disable (default: `'light'`)
+- `cssVariablePrefix`: prefix for theme color CSS variables (default: `'--shiki-'`)
+- `langAlias`: map custom language names to bundled ones (default: `{}`)
+- `structure`: `'classic'` or `'inline'` HAST/HTML shape (default: `'classic'`)
+- `tabindex`: tab index of the code block (default: `0`)
+- `meta`: arbitrary metadata passed to transformers (default: `{}`)
 
 ### Component-specific Props
 
@@ -367,7 +437,7 @@ Ensure your site sets the `color-scheme` CSS property:
 
 For broader browser support or more control, add CSS snippets to your site to enable theme switching with media queries or class-based switching. See [Shiki's documentation](https://shiki.matsu.io/guide/dual-themes) for the required CSS snippets.
 
-> **Note**: The `light-dark()` function requires modern browser support. For older browsers, use the manual CSS variables approach.
+> **Note**: The `light-dark()` function requires [modern browser support](https://caniuse.com/wf-light-dark). For older browsers, use the manual CSS variables approach.
 
 ### Custom Themes
 
@@ -385,6 +455,26 @@ import tokyoNight from "../styles/tokyo-night.json";
 const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight);
 ```
 
+When using a fine-grained highlighter via `react-shiki/core`: pass the theme as a dynamic import to `createHighlighterCore` so it stays out of the initial chunk, then reference it by its `name` field:
+
+```tsx
+const highlighter = await createHighlighterCore({
+  themes: [import("../styles/tokyo-night.json")],
+  langs: [import("@shikijs/langs/tsx")],
+  engine: createJavaScriptRegexEngine(),
+});
+
+// Component
+<ShikiHighlighter highlighter={highlighter} language="tsx" theme="tokyo-night">
+  {code.trim()}
+</ShikiHighlighter>
+
+// Hook
+const highlightedCode = useShikiHighlighter(code, "tsx", tokyoNight, {
+  highlighter,
+});
+```
+
 ### Custom Languages
 
 Custom languages should be passed as a TextMate grammar JavaScript object ([example](https://github.com/shikijs/textmate-grammars-themes/blob/main/packages/tm-grammars/grammars/typescript.json)).
@@ -398,6 +488,26 @@ import mcfunction from "../langs/mcfunction.tmLanguage.json";
 
 // Hook
 const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
+```
+
+Passing grammar objects as props works with the full and web bundles, where react-shiki creates the highlighter and loads them for you. On the core bundle you own the highlighter, so include grammars there as dynamic imports:
+
+```tsx
+const highlighter = await createHighlighterCore({
+  themes: [import("@shikijs/themes/github-dark")],
+  langs: [import("../langs/mcfunction.tmLanguage.json")],
+  engine: createJavaScriptRegexEngine(),
+});
+
+// Component
+<ShikiHighlighter highlighter={highlighter} language="mcfunction" theme="github-dark">
+  {code.trim()}
+</ShikiHighlighter>
+
+// Hook
+const highlightedCode = useShikiHighlighter(code, "mcfunction", "github-dark", {
+  highlighter,
+});
 ```
 
 #### Preloading Languages
@@ -424,7 +534,7 @@ const highlightedCode = useShikiHighlighter(code, "typescript", "github-dark", {
 ```
 
 > [!NOTE] 
-> Bundled languages are loaded on demand and do not need to be preloaded.
+> Bundled languages are loaded on demand and do not need to be preloaded. `preloadLanguages` applies to the full and web bundles; with a custom highlighter, load languages in `createHighlighterCore` instead.
 
 ### Language Aliases
 
@@ -664,57 +774,6 @@ const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
   delay: 150,
 });
 ```
-
-### Output Formats
-
-`react-shiki` can return highlighted code in three formats:
-
-**React Nodes (Default)** - Rendered as React elements, no `dangerouslySetInnerHTML` required
-```tsx
-// Hook
-const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark");
-
-// Component
-<ShikiHighlighter language="tsx" theme="github-dark">
-  {code}
-</ShikiHighlighter>
-```
-
-**HTML String** - Rendered via `dangerouslySetInnerHTML`
-```tsx
-// Hook (returns HTML string, use dangerouslySetInnerHTML to render)
-const highlightedCode = useShikiHighlighter(code, "tsx", "github-dark", {
-  outputFormat: 'html'
-});
-
-// Component (automatically uses dangerouslySetInnerHTML when outputFormat is 'html')
-<ShikiHighlighter language="tsx" theme="github-dark" outputFormat="html">
-  {code}
-</ShikiHighlighter>
-```
-
-**Shiki Tokens (Experimental)** - Hook-only output for custom renderers
-```tsx
-const highlighted = useShikiHighlighter(code, "tsx", "github-dark", {
-  outputFormat: "tokens",
-});
-
-const rendered = highlighted?.tokens.map((line, i) => (
-  <div key={i}>
-    {line.map((token, j) => (
-      <span key={j} style={{ color: token.color }}>
-        {token.content}
-      </span>
-    ))}
-  </div>
-));
-```
-
-The React and HTML formats spend their rendering work in different phases. HTML output skips per-token React element creation and reconciliation, reducing render-phase overhead for large, one-shot highlights, but each update replaces the code block's entire DOM subtree via `innerHTML`. React output pays for element creation and diffing on every update, but commits only incremental DOM mutations, minimizing DOM churn for frequently re-highlighted code such as streaming LLM output.
-
-HTML output hands the highlighted markup to the DOM via `dangerouslySetInnerHTML`, so only use it with trusted code sources. The default React output is the safe choice for untrusted content.
-
-Token output is for when you need to own rendering yourself; it is intentionally available on the hook, not the `ShikiHighlighter` component, since react-shiki's markup-based features no longer apply once you control the markup. Note that Shiki's `codeToTokens` does not run transformers or decorations, so markup-producing options, including transformers, decorations, line numbers, and `structure`, have no effect on token output.
 
 ---
 

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -17,6 +17,7 @@ export type {
   Theme,
   Themes,
   Element,
+  EngineName,
   HighlighterOptions,
   HighlighterOptionsFor,
   HighlightResult,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -17,6 +17,7 @@ export type {
   Theme,
   Themes,
   Element,
+  EngineName,
   HighlighterOptions,
   HighlighterOptionsFor,
   HighlightResult,

--- a/package/src/lib/engine.ts
+++ b/package/src/lib/engine.ts
@@ -1,0 +1,44 @@
+import type { Awaitable, RegexEngine } from 'shiki/core';
+import type { EngineName } from './types';
+
+const engines = new Map<EngineName, Awaitable<RegexEngine>>();
+
+// Dynamic imports keep unused engines out of the loaded graph: naming an
+// engine loads only that engine, and 'javascript' never fetches the wasm.
+const loaders: Record<EngineName, () => Promise<RegexEngine>> = {
+  javascript: () =>
+    import('shiki/engine/javascript').then((m) =>
+      m.createJavaScriptRegexEngine()
+    ),
+  oniguruma: () =>
+    import('shiki/engine/oniguruma').then((m) =>
+      m.createOnigurumaEngine(import('shiki/wasm'))
+    ),
+};
+
+/**
+ * Resolves a named engine to a lazily created, cached instance.
+ * Engine instances and undefined pass through untouched.
+ *
+ * The cache makes named engines referentially stable across renders and
+ * call sites, unlike inline `createJavaScriptRegexEngine()` calls.
+ */
+export const resolveEngine = (
+  engine: EngineName | Awaitable<RegexEngine> | undefined
+): Awaitable<RegexEngine> | undefined => {
+  if (typeof engine !== 'string') return engine;
+
+  const load = loaders[engine];
+  if (!load) {
+    throw new Error(
+      `[react-shiki] unknown engine '${engine}', expected 'javascript' or 'oniguruma'`
+    );
+  }
+
+  let instance = engines.get(engine);
+  if (!instance) {
+    instance = load();
+    engines.set(engine, instance);
+  }
+  return instance;
+};

--- a/package/src/lib/engine.ts
+++ b/package/src/lib/engine.ts
@@ -1,7 +1,7 @@
 import type { Awaitable, RegexEngine } from 'shiki/core';
 import type { EngineName } from './types';
 
-const engines = new Map<EngineName, Awaitable<RegexEngine>>();
+const engines = new Map<EngineName, Promise<RegexEngine>>();
 
 // Dynamic imports keep unused engines out of the loaded graph: naming an
 // engine loads only that engine, and 'javascript' never fetches the wasm.
@@ -35,10 +35,13 @@ export const resolveEngine = (
     );
   }
 
-  let instance = engines.get(engine);
-  if (!instance) {
-    instance = load();
-    engines.set(engine, instance);
-  }
+  const cached = engines.get(engine);
+  if (cached) return cached;
+
+  const instance = load();
+  // Evict rejected loads (e.g. transient wasm fetch failure) so the
+  // next highlight retries instead of reusing the cached rejection.
+  instance.catch(() => engines.delete(engine));
+  engines.set(engine, instance);
   return instance;
 };

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -24,6 +24,7 @@ import {
   resolveLoadedLanguage,
 } from './language';
 import { resolveTheme } from './theme';
+import { resolveEngine } from './engine';
 import { buildShikiOptions } from './options';
 
 export async function highlight<F extends OutputFormat = 'react'>(
@@ -46,7 +47,11 @@ export async function highlight<F extends OutputFormat = 'react'>(
   const highlighter =
     opts.highlighter ??
     (await (async () => {
-      const hl = await factory(langsToLoad, themesToLoad, opts.engine);
+      const hl = await factory(
+        langsToLoad,
+        themesToLoad,
+        resolveEngine(opts.engine)
+      );
       await hl.loadLanguage(
         ...getEmbeddedLanguages(code, languageId, hl)
       );

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -63,6 +63,11 @@ type Themes = {
 };
 
 /**
+ * Named RegExp engines that react-shiki creates and caches internally.
+ */
+type EngineName = 'javascript' | 'oniguruma';
+
+/**
  * Configuration options specific to react-shiki
  */
 interface ReactShikiOptions {
@@ -71,6 +76,19 @@ interface ReactShikiOptions {
    * @default undefined (no throttling)
    */
   delay?: number;
+
+  /**
+   * RegExp engine for syntax highlighting.
+   * - 'oniguruma': compiled WebAssembly engine, maximum grammar support
+   * - 'javascript': pure-JS engine, no WASM fetch, faster startup
+   *
+   * Named engines are created lazily and cached by react-shiki, so they
+   * are safe to pass inline. A custom engine instance is also accepted;
+   * create it once at module scope, as a new instance on every render
+   * re-triggers highlighting.
+   * @default 'oniguruma'
+   */
+  engine?: EngineName | Awaitable<RegexEngine>;
 
   /**
    * Custom textmate grammars to be preloaded for highlighting.
@@ -155,10 +173,7 @@ interface HighlighterOptions
       'defaultColor' | 'cssVariablePrefix'
     >,
     Omit<CodeToHastOptions, 'lang' | 'theme' | 'themes'>,
-    Pick<
-      BundledHighlighterOptions<string, string>,
-      'langAlias' | 'engine'
-    > {}
+    Pick<BundledHighlighterOptions<string, string>, 'langAlias'> {}
 
 /**
  * State for the throttling logic
@@ -221,6 +236,7 @@ export type {
   Theme,
   Themes,
   Element,
+  EngineName,
   TimeoutState,
   HighlighterOptions,
   HighlighterOptionsFor,

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -17,6 +17,7 @@ export type {
   Theme,
   Themes,
   Element,
+  EngineName,
   HighlighterOptions,
   HighlighterOptionsFor,
   HighlightResult,

--- a/package/tests/engine-integration.test.tsx
+++ b/package/tests/engine-integration.test.tsx
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { useShikiHighlighter, ShikiHighlighter } from '../src/index';
+
+// All tests in this file use the JavaScript engine: the underlying
+// highlighter is a singleton, so the first highlight decides the engine
+// for the whole test environment.
+
+describe("engine: 'javascript'", () => {
+  test('highlights via the hook', async () => {
+    const Harness = () => {
+      const out = useShikiHighlighter(
+        'const a = 1;',
+        'javascript',
+        'github-dark',
+        { engine: 'javascript' }
+      );
+      return <div data-testid="out">{out}</div>;
+    };
+
+    const { getByTestId } = render(<Harness />);
+    await waitFor(() => {
+      expect(getByTestId('out').textContent).toContain('const a = 1;');
+      expect(getByTestId('out').querySelector('pre')).not.toBeNull();
+    });
+  });
+
+  test('is referentially stable when passed inline: renders settle', async () => {
+    const renders = { count: 0 };
+    const Harness = () => {
+      renders.count++;
+      const out = useShikiHighlighter(
+        'const b = 2;',
+        'javascript',
+        'github-dark',
+        { engine: 'javascript' }
+      );
+      return <div data-testid="out">{out}</div>;
+    };
+
+    const { getByTestId } = render(<Harness />);
+    await waitFor(() =>
+      expect(getByTestId('out').textContent).toContain('const b = 2;')
+    );
+    const settled = renders.count;
+
+    await new Promise((r) => setTimeout(r, 300));
+    expect(renders.count).toBe(settled);
+  });
+
+  test('works as a component prop', async () => {
+    const { container } = render(
+      <ShikiHighlighter
+        language="javascript"
+        theme="github-dark"
+        engine="javascript"
+      >
+        {'const c = 3;'}
+      </ShikiHighlighter>
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('const c = 3;');
+      expect(container.querySelector('pre')).not.toBeNull();
+    });
+  });
+});

--- a/package/tests/engine.test.ts
+++ b/package/tests/engine.test.ts
@@ -44,7 +44,9 @@ describe('resolveEngine', () => {
     vi.doMock('shiki/wasm', trap('shiki/wasm'));
 
     try {
-      const { resolveEngine: resolve } = await import('../src/lib/engine');
+      const { resolveEngine: resolve } = await import(
+        '../src/lib/engine'
+      );
       const engine = await resolve('javascript');
       expect(engine).toHaveProperty('createScanner');
     } finally {
@@ -65,7 +67,9 @@ describe('resolveEngine', () => {
     }));
 
     try {
-      const { resolveEngine: resolve } = await import('../src/lib/engine');
+      const { resolveEngine: resolve } = await import(
+        '../src/lib/engine'
+      );
 
       await expect(resolve('javascript')).rejects.toThrow(
         'transient load failure'

--- a/package/tests/engine.test.ts
+++ b/package/tests/engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { resolveEngine } from '../src/lib/engine';
 
 describe('resolveEngine', () => {
@@ -8,6 +8,15 @@ describe('resolveEngine', () => {
 
     expect(first).toBeDefined();
     expect(second).toBe(first);
+
+    const engine = await first;
+    expect(engine).toHaveProperty('createScanner');
+  });
+
+  test('resolves oniguruma to a distinct cached engine', async () => {
+    const first = resolveEngine('oniguruma');
+    expect(resolveEngine('oniguruma')).toBe(first);
+    expect(first).not.toBe(resolveEngine('javascript'));
 
     const engine = await first;
     expect(engine).toHaveProperty('createScanner');
@@ -24,5 +33,50 @@ describe('resolveEngine', () => {
     expect(() => resolveEngine('typo' as never)).toThrow(
       /unknown engine 'typo'/
     );
+  });
+
+  test("resolving 'javascript' never loads the oniguruma or wasm modules", async () => {
+    vi.resetModules();
+    const trap = (name: string) => () => {
+      throw new Error(`${name} should not be imported for 'javascript'`);
+    };
+    vi.doMock('shiki/engine/oniguruma', trap('shiki/engine/oniguruma'));
+    vi.doMock('shiki/wasm', trap('shiki/wasm'));
+
+    try {
+      const { resolveEngine: resolve } = await import('../src/lib/engine');
+      const engine = await resolve('javascript');
+      expect(engine).toHaveProperty('createScanner');
+    } finally {
+      vi.doUnmock('shiki/engine/oniguruma');
+      vi.doUnmock('shiki/wasm');
+      vi.resetModules();
+    }
+  });
+
+  test('evicts rejected loads so the next call retries', async () => {
+    vi.resetModules();
+    let calls = 0;
+    vi.doMock('shiki/engine/javascript', () => ({
+      createJavaScriptRegexEngine: () => {
+        if (++calls === 1) throw new Error('transient load failure');
+        return { createScanner: () => null };
+      },
+    }));
+
+    try {
+      const { resolveEngine: resolve } = await import('../src/lib/engine');
+
+      await expect(resolve('javascript')).rejects.toThrow(
+        'transient load failure'
+      );
+
+      const engine = await resolve('javascript');
+      expect(engine).toHaveProperty('createScanner');
+      expect(calls).toBe(2);
+    } finally {
+      vi.doUnmock('shiki/engine/javascript');
+      vi.resetModules();
+    }
   });
 });

--- a/package/tests/engine.test.ts
+++ b/package/tests/engine.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest';
+import { resolveEngine } from '../src/lib/engine';
+
+describe('resolveEngine', () => {
+  test('returns a stable cached instance for named engines', async () => {
+    const first = resolveEngine('javascript');
+    const second = resolveEngine('javascript');
+
+    expect(first).toBeDefined();
+    expect(second).toBe(first);
+
+    const engine = await first;
+    expect(engine).toHaveProperty('createScanner');
+  });
+
+  test('passes engine instances and undefined through untouched', async () => {
+    expect(resolveEngine(undefined)).toBeUndefined();
+
+    const custom = await resolveEngine('javascript');
+    expect(resolveEngine(custom)).toBe(custom);
+  });
+
+  test('throws on unknown engine names', () => {
+    expect(() => resolveEngine('typo' as never)).toThrow(
+      /unknown engine 'typo'/
+    );
+  });
+});

--- a/playground/src/Demo.mdx
+++ b/playground/src/Demo.mdx
@@ -1,6 +1,10 @@
-import ShikiHighlighter from 'react-shiki';
+import Shiki from 'react-shiki';
 import mcfunction from './assets/mcfunction.tmLanguage.json';
 import bosque from './assets/bosque.tmLanguage.json';
+
+export const ShikiHighlighter = (props) => (
+  <Shiki engine="javascript" {...props} />
+);
 
 # 🎨 react-shiki
 


### PR DESCRIPTION
## Summary

`engine` now accepts `'javascript'` and `'oniguruma'` as strings. react-shiki creates and caches the engine internally.

```tsx
// hook
useShikiHighlighter(code, 'tsx', 'github-dark', { engine: 'javascript' });

// component
<ShikiHighlighter language="tsx" theme="github-dark" engine="javascript">
  {code}
</ShikiHighlighter>
```

## Why

Before this, switching engines meant importing `createJavaScriptRegexEngine()` and passing the result in yourself. Easy to get wrong:

- Calling it inline creates a new object every render, which breaks memoization and re-triggers highlighting in a loop
- The highlighter is a singleton that only uses the engine on first creation, so you had to pass the same engine everywhere

Strings have neither problem: they're stable, and react-shiki caches one engine per name. Engines load with dynamic `import()`, so `'javascript'` never fetches the WASM and engines you don't use are never loaded.

`'javascript-raw'` is excluded because it needs pre-compiled grammars that the full/web bundles don't ship. You can still pass your own engine for that (README shows it with the core bundle).

## Changes

- `lib/engine.ts` (new): `resolveEngine` with lazy loaders and a per-name cache
- `lib/types.ts`: `engine?: EngineName | Awaitable<RegexEngine>`, `EngineName` exported
- README: recommends the string form + 0.12 default-swap heads-up
- Tests: resolver unit tests, hook/component integration, render-settling regression

> [!NOTE]
> The next minor release will swap the default engine from Oniguruma WASM to the JavaScript engine (with `forgiving` enabled by default, see [shiki/regex-engines](https://shiki.style/guide/regex-engines#use-with-unsupported-languages)).