### PR TITLE
feat: preloadLanguages accepts dynamic grammar imports

### DIFF
--- a/.changeset/dynamic-preload-languages.md
+++ b/.changeset/dynamic-preload-languages.md
@@ -1,0 +1,15 @@
+---
+"react-shiki": patch
+---
+
+`preloadLanguages` now accepts dynamic grammar imports (shiki's `LanguageInput`) on the full and web bundles, so custom grammars can stay code-split instead of shipping in the main bundle:
+
+```tsx
+const preload = [() => import("../langs/mcfunction.tmLanguage.json")];
+
+<ShikiHighlighter language="mcfunction" preloadLanguages={preload}>
+  {code}
+</ShikiHighlighter>
+```
+
+Promises, getters, and module objects are all accepted and resolved by shiki during highlighter setup. Define them at module scope; a fresh promise or arrow function on every render re-triggers highlighting. Additive only: strings and grammar objects work exactly as before.

--- a/package/README.md
+++ b/package/README.md
@@ -533,6 +533,27 @@ const highlightedCode = useShikiHighlighter(code, "typescript", "github-dark", {
 });
 ```
 
+Custom grammars can also be dynamic imports, keeping them out of the main bundle. Reference them by the grammar's `name` field:
+
+```tsx
+// Module scope: stable identity across renders, fetched on first highlight
+const preloadLanguages = [
+  () => import("../langs/mcfunction.tmLanguage.json"),
+  () => import("../langs/bosque.tmLanguage.json"),
+];
+
+<ShikiHighlighter
+  language="mcfunction"
+  theme="github-dark"
+  preloadLanguages={preloadLanguages}
+>
+  {code.trim()}
+</ShikiHighlighter>
+```
+
+> [!IMPORTANT]
+> Define dynamic imports at module scope. A fresh `import()` promise or arrow function on every render re-triggers highlighting.
+
 > [!NOTE] 
 > Bundled languages are loaded on demand and do not need to be preloaded. `preloadLanguages` applies to the full and web bundles; with a custom highlighter, load languages in `createHighlighterCore` instead.
 

--- a/package/README.md
+++ b/package/README.md
@@ -44,7 +44,7 @@ A performant client-side syntax highlighting component and hook for React, built
 - 🖼️ Provides both a `ShikiHighlighter` component and a `useShikiHighlighter` hook for more flexibility
 - 🔐 Flexible output: Choose between React elements (no `dangerouslySetInnerHTML`) or HTML strings
 - 📦 Multiple bundle options: Full bundle (~1.2MB gz), web bundle (~707KB gz), or minimal core bundle for fine-grained bundle control
-- 🖌️ Full support for custom TextMate themes and languages
+- 🖌️ Full support for custom TextMate themes and languages, passed as objects or dynamic imports
 - 🧬 Automatic highlighting of embedded languages (e.g. TypeScript fenced inside Markdown) via Shiki's `guessEmbeddedLanguages`
 - 🔧 Supports passing custom Shiki transformers to the highlighter, in addition to all other options supported by `codeToHast`
 - 🚰 Performant highlighting of streamed code, with optional throttling
@@ -309,7 +309,7 @@ The core inputs, positional arguments on the hook, props/children on the compone
 | `engine`            | `'javascript' \| 'oniguruma' \| RegexEngine` | `'oniguruma'` | RegExp engine for syntax highlighting; named engines are created and cached internally |
 | `highlighter`       | `Highlighter \| HighlighterCore` | -  | Custom highlighter instance, required for the core bundle                     |
 | `outputFormat`      | `string`           | `'react'`       | Output format: 'react' for React nodes, 'html' for HTML string, or 'tokens' for Shiki tokens (hook only, experimental) |
-| `preloadLanguages`  | `array`            | `[]`            | Preload bundled language IDs and custom language grammars |
+| `preloadLanguages`  | `array`            | `[]`            | Preload bundled language IDs, custom grammar objects, or dynamic grammar imports |
 | `customLanguages`   | `array`            | `[]`            | **Deprecated**: use `preloadLanguages` instead. |
 | `showLineNumbers`   | `boolean`          | `false`         | Display line numbers alongside code                                           |
 | `startingLineNumber` | `number`           | `1`             | Starting line number when line numbers are enabled                           |
@@ -490,7 +490,9 @@ import mcfunction from "../langs/mcfunction.tmLanguage.json";
 const highlightedCode = useShikiHighlighter(code, mcfunction, "github-dark");
 ```
 
-Passing grammar objects as props works with the full and web bundles, where react-shiki creates the highlighter and loads them for you. On the core bundle you own the highlighter, so include grammars there as dynamic imports:
+Passing grammar objects as props works with the full and web bundles, where react-shiki creates the highlighter and loads them for you. To keep custom grammars out of the main bundle, pass them as dynamic imports via `preloadLanguages` and reference them by name — see [Preloading Languages](#preloading-languages).
+
+On the core bundle you own the highlighter, so include grammars there as dynamic imports:
 
 ```tsx
 const highlighter = await createHighlighterCore({

--- a/package/README.md
+++ b/package/README.md
@@ -552,7 +552,7 @@ const preloadLanguages = [
 ```
 
 > [!IMPORTANT]
-> Define dynamic imports at module scope. A fresh `import()` promise or arrow function on every render re-triggers highlighting.
+> Define dynamic imports at module scope, preferring the getter form (`() => import(...)`). A fresh arrow function on every render re-triggers highlighting; bare promises are compared by type, so swapping one at runtime won't be picked up.
 
 > [!NOTE] 
 > Bundled languages are loaded on demand and do not need to be preloaded. `preloadLanguages` applies to the full and web bundles; with a custom highlighter, load languages in `createHighlighterCore` instead.

--- a/package/src/bundles/factory.ts
+++ b/package/src/bundles/factory.ts
@@ -5,11 +5,15 @@ import type {
   HighlighterCore,
   RegexEngine,
 } from 'shiki/core';
-import type { HighlighterFactory, Language, Theme } from '../lib/types';
+import type {
+  HighlighterFactory,
+  PreloadLanguage,
+  Theme,
+} from '../lib/types';
 import { isLoadableLanguage } from '../lib/language';
 
 type GetSingletonHighlighter = (options: {
-  langs: NonNullable<Language>[];
+  langs: NonNullable<PreloadLanguage>[];
   themes: Theme[];
   engine: Awaitable<RegexEngine>;
 }) => Promise<HighlighterCore>;

--- a/package/src/core.ts
+++ b/package/src/core.ts
@@ -14,6 +14,7 @@ export type { ShikiHighlighterProps };
 export type {
   UseShikiHighlighter,
   Language,
+  PreloadLanguage,
   Theme,
   Themes,
   Element,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -14,6 +14,7 @@ export type { ShikiHighlighterProps };
 export type {
   UseShikiHighlighter,
   Language,
+  PreloadLanguage,
   Theme,
   Themes,
   Element,

--- a/package/src/lib/hook.ts
+++ b/package/src/lib/hook.ts
@@ -11,6 +11,7 @@ import type {
   HighlightResultMap,
   Language,
   OutputFormat,
+  PreloadLanguage,
   Theme,
   Themes,
   TimeoutState,
@@ -31,7 +32,7 @@ export async function highlight<F extends OutputFormat = 'react'>(
   code: string,
   resolved: {
     languageId: string;
-    langsToLoad: Language[];
+    langsToLoad: PreloadLanguage[];
     themesToLoad: Theme[];
     shikiOptions: CodeToHastOptions;
   },

--- a/package/src/lib/language.ts
+++ b/package/src/lib/language.ts
@@ -1,4 +1,4 @@
-import type { Language } from './types';
+import type { Language, PreloadLanguage } from './types';
 import { guessEmbeddedLanguages, isSpecialLang } from 'shiki/core';
 import type {
   DynamicImportLanguageRegistration,
@@ -27,21 +27,33 @@ export const getEmbeddedLanguages = (
  */
 type LanguageResult = {
   languageId: string;
-  langsToLoad: Language[];
+  langsToLoad: PreloadLanguage[];
 };
 
 const toArray = <T>(value?: T | T[]): T[] =>
   value == null ? [] : Array.isArray(value) ? value : [value];
 
-const languageKey = (lang: Language): string | null => {
+/** Deferred `LanguageInput` forms (getter, promise, module, array) that shiki resolves itself */
+type DynamicLanguage = Exclude<LanguageInput, LanguageRegistration>;
+
+const isDynamicLanguage = (
+  lang: PreloadLanguage
+): lang is DynamicLanguage =>
+  typeof lang === 'function' ||
+  lang instanceof Promise ||
+  Array.isArray(lang) ||
+  (typeof lang === 'object' && lang != null && 'default' in lang);
+
+const languageKey = (lang: PreloadLanguage): string | object | null => {
   if (lang == null) return null;
   if (typeof lang === 'string') return `s:${lang}`;
+  if (isDynamicLanguage(lang)) return lang;
   return `o:${lang.name}::${lang.scopeName}`;
 };
 
-const dedupeLanguages = (langs: Language[]): Language[] => {
-  const seen = new Set<string>();
-  const deduped: Language[] = [];
+const dedupeLanguages = (langs: PreloadLanguage[]): PreloadLanguage[] => {
+  const seen = new Set<string | object>();
+  const deduped: PreloadLanguage[] = [];
 
   for (const lang of langs) {
     const key = languageKey(lang);
@@ -55,14 +67,16 @@ const dedupeLanguages = (langs: Language[]): Language[] => {
 
 /**
  * Used in factories to check if language is supported.
- * Objects are validated as grammar registrations (name + scopeName).
+ * Objects are validated as grammar registrations (name + scopeName);
+ * dynamic imports pass through for shiki to resolve.
  */
 export const isLoadableLanguage = <T extends string>(
-  lang: Language,
+  lang: PreloadLanguage,
   bundledLanguages: Record<T, DynamicImportLanguageRegistration>
-): lang is NonNullable<Language> => {
+): lang is NonNullable<PreloadLanguage> => {
   if (lang == null) return false;
   if (typeof lang === 'string') return lang in bundledLanguages;
+  if (isDynamicLanguage(lang)) return true;
   return (
     typeof lang.name === 'string' && typeof lang.scopeName === 'string'
   );
@@ -106,7 +120,7 @@ export const resolveLanguage = (
   lang: Language,
   customLanguages?: LanguageRegistration | LanguageRegistration[],
   langAliases?: Record<string, string>,
-  preloadLanguages?: Language | Language[]
+  preloadLanguages?: PreloadLanguage | PreloadLanguage[]
 ): LanguageResult => {
   const customLangs = toArray(customLanguages);
   const preloadLangs = toArray(preloadLanguages);
@@ -141,6 +155,7 @@ export const resolveLanguage = (
     (candidate): candidate is LanguageRegistration =>
       typeof candidate === 'object' &&
       candidate != null &&
+      !isDynamicLanguage(candidate) &&
       registrationMatches(candidate, matches)
   );
   if (customMatch) {

--- a/package/src/lib/language.ts
+++ b/package/src/lib/language.ts
@@ -10,26 +10,6 @@ import type {
 
 export const FALLBACK_LANGUAGE = 'plaintext';
 
-export const getEmbeddedLanguages = (
-  code: string,
-  languageId: string,
-  highlighter: Highlighter | HighlighterCore
-): LanguageInput[] => {
-  const bundled: Record<string, LanguageInput> =
-    highlighter.getBundledLanguages();
-  return guessEmbeddedLanguages(code, languageId).flatMap(
-    (language) => bundled[language] ?? []
-  );
-};
-
-/**
- * Resolved languages and metadata
- */
-type LanguageResult = {
-  languageId: string;
-  langsToLoad: PreloadLanguage[];
-};
-
 const toArray = <T>(value?: T | T[]): T[] =>
   value == null ? [] : Array.isArray(value) ? value : [value];
 
@@ -44,6 +24,12 @@ const isDynamicLanguage = (
   Array.isArray(lang) ||
   (typeof lang === 'object' && lang != null && 'default' in lang);
 
+const isRegistration = (
+  lang: PreloadLanguage
+): lang is LanguageRegistration =>
+  typeof lang === 'object' && lang != null && !isDynamicLanguage(lang);
+
+/** Dedupe identity: strings and registrations by value, dynamic inputs by reference */
 const languageKey = (lang: PreloadLanguage): string | object | null => {
   if (lang == null) return null;
   if (typeof lang === 'string') return `s:${lang}`;
@@ -53,46 +39,13 @@ const languageKey = (lang: PreloadLanguage): string | object | null => {
 
 const dedupeLanguages = (langs: PreloadLanguage[]): PreloadLanguage[] => {
   const seen = new Set<string | object>();
-  const deduped: PreloadLanguage[] = [];
-
-  for (const lang of langs) {
+  return langs.filter((lang) => {
     const key = languageKey(lang);
-    if (key == null || seen.has(key)) continue;
+    if (key == null || seen.has(key)) return false;
     seen.add(key);
-    deduped.push(lang);
-  }
-
-  return deduped;
+    return true;
+  });
 };
-
-/**
- * Used in factories to check if language is supported.
- * Objects are validated as grammar registrations (name + scopeName);
- * dynamic imports pass through for shiki to resolve.
- */
-export const isLoadableLanguage = <T extends string>(
-  lang: PreloadLanguage,
-  bundledLanguages: Record<T, DynamicImportLanguageRegistration>
-): lang is NonNullable<PreloadLanguage> => {
-  if (lang == null) return false;
-  if (typeof lang === 'string') return lang in bundledLanguages;
-  if (isDynamicLanguage(lang)) return true;
-  return (
-    typeof lang.name === 'string' && typeof lang.scopeName === 'string'
-  );
-};
-
-/**
- * Used in hook to resolve loaded language for highlighting.
- * Falls back to "plaintext" if not supported.
- */
-export const resolveLoadedLanguage = (
-  languageId: string,
-  loadedLanguages: string[]
-): string =>
-  isSpecialLang(languageId) || loadedLanguages.includes(languageId)
-    ? languageId
-    : FALLBACK_LANGUAGE;
 
 /**
  * A registration matches a query by name, scopeName (full or its last
@@ -108,13 +61,14 @@ const registrationMatches = (
   !!candidate.aliases?.some(matches) ||
   !!candidate.fileTypes?.some(matches);
 
+type LanguageResult = {
+  languageId: string;
+  langsToLoad: PreloadLanguage[];
+};
+
 /**
- * Resolves the language input to standardized IDs and objects for Shiki
- * @param lang The language input from props
- * @param customLanguages An array of custom textmate grammar objects or a single grammar object
- * @returns A LanguageResult object containing:
- *   - languageId: The resolved language ID
- *   - langsToLoad: The language objects/string ids to load
+ * Resolves the language prop to a shiki language id plus everything the
+ * factory should load (primary, preloaded, and custom grammars, deduped).
  */
 export const resolveLanguage = (
   lang: Language,
@@ -151,13 +105,9 @@ export const resolveLanguage = (
     str?.toLowerCase() === query;
 
   // Custom registrations (from both customLanguages and preloadLanguages)
-  const customMatch = [...customLangs, ...preloadLangs].find(
-    (candidate): candidate is LanguageRegistration =>
-      typeof candidate === 'object' &&
-      candidate != null &&
-      !isDynamicLanguage(candidate) &&
-      registrationMatches(candidate, matches)
-  );
+  const customMatch = [...customLangs, ...preloadLangs]
+    .filter(isRegistration)
+    .find((candidate) => registrationMatches(candidate, matches));
   if (customMatch) {
     return result(customMatch.name || normalized, customMatch);
   }
@@ -171,4 +121,45 @@ export const resolveLanguage = (
 
   // Any other string passes through to the factory
   return result(normalized, normalized);
+};
+
+/**
+ * Used in factories to check if language is supported.
+ * Objects are validated as grammar registrations (name + scopeName);
+ * dynamic imports pass through for shiki to resolve.
+ */
+export const isLoadableLanguage = <T extends string>(
+  lang: PreloadLanguage,
+  bundledLanguages: Record<T, DynamicImportLanguageRegistration>
+): lang is NonNullable<PreloadLanguage> => {
+  if (lang == null) return false;
+  if (typeof lang === 'string') return lang in bundledLanguages;
+  if (isDynamicLanguage(lang)) return true;
+  return (
+    typeof lang.name === 'string' && typeof lang.scopeName === 'string'
+  );
+};
+
+/**
+ * Used in hook to resolve loaded language for highlighting.
+ * Falls back to "plaintext" if not supported.
+ */
+export const resolveLoadedLanguage = (
+  languageId: string,
+  loadedLanguages: string[]
+): string =>
+  isSpecialLang(languageId) || loadedLanguages.includes(languageId)
+    ? languageId
+    : FALLBACK_LANGUAGE;
+
+export const getEmbeddedLanguages = (
+  code: string,
+  languageId: string,
+  highlighter: Highlighter | HighlighterCore
+): LanguageInput[] => {
+  const bundled: Record<string, LanguageInput> =
+    highlighter.getBundledLanguages();
+  return guessEmbeddedLanguages(code, languageId).flatMap(
+    (language) => bundled[language] ?? []
+  );
 };

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -7,6 +7,7 @@ import type {
   CodeToHastOptions,
   Highlighter,
   HighlighterCore,
+  LanguageInput,
   LanguageRegistration,
   RegexEngine,
   SpecialLanguage,
@@ -33,6 +34,13 @@ type Language =
   | StringLiteralUnion<BundledLanguage>
   | SpecialLanguage
   | undefined;
+
+/**
+ * A `preloadLanguages` entry: a bundled language id, a custom grammar
+ * object, or a dynamic grammar import (shiki's `LanguageInput`), e.g.
+ * `() => import('../langs/mcfunction.json')`
+ */
+type PreloadLanguage = Language | LanguageInput;
 
 type MultiThemeKey = 'dark' | 'light' | (string & {});
 
@@ -99,8 +107,15 @@ interface ReactShikiOptions {
   /**
    * Preload custom grammars or bundled languages.
    * Supports custom textmate grammars, replaces deprecated `customLanguages`
+   *
+   * Full/web bundles also accept dynamic grammar imports, keeping custom
+   * grammars out of the main bundle. Define them at module scope; a fresh
+   * promise or getter each render re-triggers highlighting.
+   *
+   * @example
+   * const preload = [() => import('../langs/mcfunction.json')];
    */
-  preloadLanguages?: Language | Language[];
+  preloadLanguages?: PreloadLanguage | PreloadLanguage[];
 
   /**
    * Output format for the highlighted code.
@@ -219,7 +234,7 @@ type HighlighterOptionsFor<F extends OutputFormat> = Omit<
 > & { outputFormat?: F };
 
 type HighlighterFactory = (
-  langsToLoad: Language[],
+  langsToLoad: PreloadLanguage[],
   themesToLoad: Theme[],
   engine?: Awaitable<RegexEngine>
 ) => Promise<Highlighter | HighlighterCore>;
@@ -233,6 +248,7 @@ export type UseShikiHighlighter = <F extends OutputFormat = 'react'>(
 
 export type {
   Language,
+  PreloadLanguage,
   Theme,
   Themes,
   Element,

--- a/package/src/web.ts
+++ b/package/src/web.ts
@@ -14,6 +14,7 @@ export type { ShikiHighlighterProps };
 export type {
   UseShikiHighlighter,
   Language,
+  PreloadLanguage,
   Theme,
   Themes,
   Element,

--- a/package/tests/hook.test.tsx
+++ b/package/tests/hook.test.tsx
@@ -8,6 +8,7 @@ import { useShikiHighlighter as useShikiHighlighterCore } from '../src/core';
 import type {
   HighlightResult,
   Language,
+  PreloadLanguage,
   Theme,
   Themes,
 } from '../src/lib/types';
@@ -21,6 +22,7 @@ interface TestComponentProps {
   theme: Theme | Themes;
   transformers?: ShikiTransformer[];
   langAlias?: Record<string, string>;
+  preloadLanguages?: PreloadLanguage[];
   showLineNumbers?: boolean;
   startingLineNumber?: number;
   highlightLineNumbers?: number[];
@@ -182,6 +184,50 @@ describe('useShikiHighlighter Hook', () => {
         expect(preElement?.textContent).toBe(code);
         expect(lineSpan?.querySelectorAll('span[style]').length).toBe(0);
       });
+    });
+  });
+
+  describe('Dynamic Language Imports', () => {
+    const pointGrammar = {
+      name: 'point',
+      scopeName: 'source.point',
+      patterns: [{ match: '\\b(move|draw)\\b', name: 'keyword.control' }],
+      repository: {},
+    };
+
+    const expectHighlightedKeyword = async (
+      getByTestId: (id: string) => HTMLElement
+    ) => {
+      await waitFor(() => {
+        const preElement =
+          getByTestId('highlighted').querySelector('pre');
+        const keyword = Array.from(
+          preElement?.querySelectorAll('span') || []
+        ).find((span) => span.textContent === 'move');
+
+        expect(keyword).toBeInTheDocument();
+        expect(keyword).toHaveStyle('color: #D73A49');
+      });
+    };
+
+    test('highlights with a grammar preloaded via getter', async () => {
+      const { getByTestId } = renderComponent({
+        code: 'move 10 20',
+        language: 'point',
+        preloadLanguages: [() => Promise.resolve(pointGrammar)],
+      });
+
+      await expectHighlightedKeyword(getByTestId);
+    });
+
+    test('highlights with a grammar preloaded via module promise', async () => {
+      const { getByTestId } = renderComponent({
+        code: 'move 10 20',
+        language: 'point',
+        preloadLanguages: [Promise.resolve({ default: pointGrammar })],
+      });
+
+      await expectHighlightedKeyword(getByTestId);
     });
   });
 

--- a/package/tests/language.test.ts
+++ b/package/tests/language.test.ts
@@ -35,6 +35,18 @@ describe('isLoadableLanguage', () => {
     ).toBe(true);
   });
 
+  test('returns true for dynamic language inputs', () => {
+    expect(
+      isLoadableLanguage(
+        () => Promise.resolve({}) as any,
+        bundledLanguages
+      )
+    ).toBe(true);
+    expect(
+      isLoadableLanguage(Promise.resolve({}) as any, bundledLanguages)
+    ).toBe(true);
+  });
+
   test('returns false for incomplete language registration objects', () => {
     expect(
       isLoadableLanguage(
@@ -221,6 +233,33 @@ describe('resolveLanguage', () => {
     ).toEqual({
       languageId: 'typescript',
       langsToLoad: ['typescript', 'javascript', customLanguage],
+    });
+  });
+
+  test('passes dynamic imports through to the factory', () => {
+    const grammarImport = () => Promise.resolve(customLanguage);
+    expect(
+      resolveLanguage('my-language', undefined, undefined, [
+        grammarImport,
+      ])
+    ).toEqual({
+      languageId: 'my-language',
+      langsToLoad: ['my-language', grammarImport],
+    });
+  });
+
+  test('dedupes dynamic imports by reference', () => {
+    const grammarImport = () => Promise.resolve(customLanguage);
+    const otherImport = () => Promise.resolve(customLanguage);
+    expect(
+      resolveLanguage('typescript', undefined, undefined, [
+        grammarImport,
+        grammarImport,
+        otherImport,
+      ])
+    ).toEqual({
+      languageId: 'typescript',
+      langsToLoad: ['typescript', grammarImport, otherImport],
     });
   });
 


### PR DESCRIPTION
## Summary

`preloadLanguages` now accepts shiki's `LanguageInput` entries (getters, promises, module objects) on the full and web bundles, so custom grammars can stay code-split instead of shipping in the main bundle:

```tsx
const preload = [() => import("../langs/mcfunction.tmLanguage.json")];

<ShikiHighlighter language="mcfunction" preloadLanguages={preload}>
  {code}
</ShikiHighlighter>
```

Shiki's `getSingletonHighlighter` already resolves `LanguageInput` natively; this unblocks react-shiki's resolution layer:

- New public `PreloadLanguage = Language | LanguageInput` type, exported from all three entries
- Dynamic entries skip the string-match pool (they can't be matched until shiki resolves them), dedupe by reference (previously they'd all collapse to one `o:undefined::undefined` key), and pass the factory's loadability filter
- The `isDynamicLanguage` guard narrows to `Exclude<LanguageInput, LanguageRegistration>` so the registration branch stays fully typed with no casts

## Additive only

- Strings and grammar objects behave exactly as before; all 22 prior `language.test.ts` tests untouched and passing
- Core bundle unchanged: `preloadLanguages` remains a no-op with a custom highlighter
- Ships as a patch via changeset

## Testing

- Unit: dynamic entries pass the loadability filter, pass through resolution, dedupe by reference
- End-to-end: getter-loaded and module-promise-loaded grammars produce highlighted tokens
- 125 tests pass, typecheck/build/attw/publint clean

## Docs

README Preloading Languages section gains the dynamic import example with an IMPORTANT callout: define entries at module scope, since a fresh promise or arrow per render re-triggers highlighting.